### PR TITLE
feat: add client_id to jx-requirements

### DIFF
--- a/cluster/jx-requirements.yml.tpl
+++ b/cluster/jx-requirements.yml.tpl
@@ -17,6 +17,8 @@ spec:
         tenantId: ${dns_tenant_id}
         subscriptionId: ${dns_subscription_id}
   %{ endif }
+      clusterNodes:
+        clientID: ${kubelet_client_id}
   environments:
     - key: dev
   ingress:

--- a/cluster/requirements.tf
+++ b/cluster/requirements.tf
@@ -14,6 +14,7 @@ locals {
     log_container_name   = module.storage.log_container_name
     storage_account_name = module.storage.storage_account_name
     vault_installed      = module.jx-boot.vault_instance_release_id != "" ? true : false
+    kubelet_client_id    = module.cluster.kubelet_client_id
   })
 
   jx_requirements_split_content   = split("\n", local.jx_requirements_interpolated_content)

--- a/cluster/terraform-jx-cluster-aks/cluster/outputs.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/outputs.tf
@@ -25,6 +25,9 @@ output "node_resource_group" {
 output "kubelet_identity_id" {
   value = azurerm_kubernetes_cluster.aks.kubelet_identity.0.object_id
 }
+output "kubelet_client_id" {
+  value = azurerm_kubernetes_cluster.aks.kubelet_identity.0.client_id
+}
 output "kubernetes_cluster" {
   value = azurerm_kubernetes_cluster.aks
 }

--- a/cluster/terraform-jx-cluster-aks/outputs.tf
+++ b/cluster/terraform-jx-cluster-aks/outputs.tf
@@ -4,6 +4,9 @@ output "connect" {
 output "kubelet_identity_id" {
   value = module.cluster.kubelet_identity_id
 }
+output "kubelet_client_id" {
+  value = module.cluster.kubelet_client_id
+}
 output "cluster_endpoint" {
   value = module.cluster.cluster_endpoint
 }


### PR DESCRIPTION
add the cluster nodes resource group client id to jx-requirements so that we can pull it into build-scan-push