### PR TITLE
chore: upgrade to latest azurerm version

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.4.6"
   required_providers {
     random = {
       version = ">=3.0.0"
@@ -8,7 +8,7 @@ terraform {
       version = ">=1.13.3"
     }
     azurerm = {
-      version = ">=2.99.0"
+      version = ">=3.0.0"
     }
   }
 }
@@ -95,6 +95,7 @@ module "cluster" {
   subnet_cidr                      = var.subnet_cidr
   vnet_cidr                        = var.vnet_cidr
   azure_policy_bool                = var.azure_policy_bool
+  microsoft_defender_log_id = module.cluster.microsoft_defender_log_id
 }
 
 module "registry" {

--- a/cluster/terraform-jx-azure-storage/main.tf
+++ b/cluster/terraform-jx-azure-storage/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 0.13.2"
   required_providers {
     azurerm = {
-      version = ">=2.56.0"
+      version = ">=3.0.0"
     }
   }
 }
@@ -24,6 +24,7 @@ resource "azurerm_storage_account" "storage" {
   account_tier             = "Standard"
   account_kind             = "StorageV2"
   is_hns_enabled           = true
+  allow_nested_items_to_be_public = false
 }
 
 resource "azurerm_storage_container" "logs" {

--- a/cluster/terraform-jx-azuredns/main.tf
+++ b/cluster/terraform-jx-azuredns/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.3.2"
   required_providers {
     azurerm = {
-      version = ">=2.39.0"
+      version = ">=3.0.0"
     }
   }
 }

--- a/cluster/terraform-jx-azurekeyvault/main.tf
+++ b/cluster/terraform-jx-azurekeyvault/main.tf
@@ -3,10 +3,10 @@
 //
 // ----------------------------------------------------------------------------
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=2.48.0, <= 2.300.0"
+      version = ">=2.99.0"
     }
   }
 }
@@ -50,9 +50,9 @@ resource "azurerm_key_vault_access_policy" "jx" {
   tenant_id    = local.tenant_id
 
   secret_permissions = [
-    "get",
-    "set",
-    "delete",
+    "Get",
+    "Set",
+    "Delete",
   ]
 }
 
@@ -63,8 +63,8 @@ resource "azurerm_key_vault_access_policy" "terraform" {
   tenant_id    = local.tenant_id
 
   secret_permissions = [
-    "get",
-    "set",
-    "delete",
+    "Get",
+    "Set",
+    "Delete",
   ]
 }

--- a/cluster/terraform-jx-boot/boot.tf
+++ b/cluster/terraform-jx-boot/boot.tf
@@ -3,7 +3,7 @@ resource "helm_release" "jx-git-operator" {
   chart            = "jx-git-operator"
   namespace        = "jx-git-operator"
   repository       = "https://jenkins-x-charts.github.io/repo"
-  version          = "0.1.7"
+  version          = "0.1.9"
   create_namespace = true
 
   set {

--- a/cluster/terraform-jx-cluster-aks/cluster/logging.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/logging.tf
@@ -6,3 +6,11 @@ resource "azurerm_log_analytics_workspace" "cluster" {
   sku                 = "PerGB2018"
   retention_in_days   = var.logging_retention_days
 }
+
+resource "azurerm_log_analytics_workspace" "microsoft_defender" {
+  name                = var.microsoft_defender_log_analytics_name
+  location            = var.location
+  resource_group_name = var.defender_resource_group
+  sku                 = "PerGB2018"
+  retention_in_days   = var.logging_retention_days
+}

--- a/cluster/terraform-jx-cluster-aks/cluster/outputs.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/outputs.tf
@@ -31,3 +31,6 @@ output "kubelet_client_id" {
 output "kubernetes_cluster" {
   value = azurerm_kubernetes_cluster.aks
 }
+output "microsoft_defender_log_id" {
+  value = azurerm_log_analytics_workspace.microsoft_defender.id
+}

--- a/cluster/terraform-jx-cluster-aks/cluster/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/variables.tf
@@ -210,3 +210,17 @@ variable "azure_policy_bool" {
   type = bool
 }
 
+
+variable "microsoft_defender_log_analytics_name" {
+  type = string
+  default = "DefaultWorkspace-5429b748-8754-45b3-bbab-036e0cc418ee-SUK"
+}
+
+variable "microsoft_defender_log_id" {
+  type = string
+}
+
+variable "defender_resource_group" {
+  type = string
+}
+

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -3,10 +3,10 @@
 //
 // ----------------------------------------------------------------------------
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=2.57.0"
+      version = ">=3.0.0"
     }
   }
 }
@@ -23,6 +23,11 @@ data "azurerm_subscription" "current" {
 
 resource "azurerm_resource_group" "network" {
   name     = local.network_resource_group_name
+  location = var.location
+}
+
+resource "azurerm_resource_group" "default_suk" {
+  name     = var.default_rg
   location = var.location
 }
 
@@ -79,6 +84,8 @@ module "cluster" {
   min_mlbuild_node_count           = var.min_mlbuild_node_count
   max_mlbuild_node_count           = var.max_mlbuild_node_count
   azure_policy_bool                = var.azure_policy_bool
+  microsoft_defender_log_id        = module.cluster.microsoft_defender_log_id
+  defender_resource_group          = azurerm_resource_group.default_suk.name
 }
 
 // ----------------------------------------------------------------------------

--- a/cluster/terraform-jx-cluster-aks/outputs.tf
+++ b/cluster/terraform-jx-cluster-aks/outputs.tf
@@ -25,3 +25,6 @@ output "kube_config_admin_raw" {
 output "kube_config_admin" {
   value = module.cluster.kube_config_admin
 }
+output "microsoft_defender_log_id" {
+  value = module.cluster.microsoft_defender_log_id
+}

--- a/cluster/terraform-jx-cluster-aks/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/variables.tf
@@ -229,3 +229,12 @@ variable "logging_retention_days" {
 variable "azure_policy_bool" {
   type = bool
 }
+
+variable "microsoft_defender_log_id" {
+  type = string
+}
+
+variable "default_rg" {
+  type = string
+  default = "DefaultResourceGroup-SUK"
+}

--- a/cluster/terraform-jx-registry-acr-oss/main.tf
+++ b/cluster/terraform-jx-registry-acr-oss/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.3.2"
   required_providers {
     azurerm = {
-      version = ">=2.56.0"
+      version = ">=3.0.0"
     }
   }
 }

--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.3.2"
   required_providers {
     azurerm = {
-      version = ">=2.56.0"
+      version = ">=3.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.3.2"
+  required_version = ">=1.4.6"
   backend "remote" {
     organization = "mqube"
 

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -1,6 +1,6 @@
 jx_git_url                       = "https://github.com/spring-financial-group/JX3_Azure_Vault_Dev_Cluster"
 cluster_name                     = "jx3-mqube-build"
-sku_tier                         = "Paid"
+sku_tier                         = "Standard"
 location                         = "uksouth"
 network_resource_group_name      = "mqubejx3build-network_rsg"
 cluster_resource_group_name      = "mqubejx3build-cluster_rsg"

--- a/variables.tf
+++ b/variables.tf
@@ -13,7 +13,6 @@ variable "location" {
 // ----------------------------------------------------------------------------
 // JX Boot variables
 // ----------------------------------------------------------------------------
-
 variable "jx_git_url" {
   description = "URL for the Jenkins X cluster git repository"
   type        = string


### PR DESCRIPTION
k8s 1.27.3 and AzureRM 3.0.0 UPGRADE:

NOTE: Due to the k8s 1.27.3 and Azurerm 3.0.0 + there is drift and new behaviour with the many AKS resources.

Changes in this PR:
- upgrade to latest azurerm version
- terraform init --upgrade applied which has upgraded all version and kept up to date with remote workspace
- microsoft defender resource group and log analytics workspace now managed and associated with the cluster
- SKU Tier changed from ' Paid ' to ' Standard '
- changes in AKS cluster for current config due to addon profile being deprecated:
```
  role_based_access_control {
    enabled = true

    azure_active_directory {
      managed = true
    }
  }

  addon_profile {
    dynamic "oms_agent" {
      for_each = var.enable_log_analytics ? [""] : []
      content {
        enabled                    = var.enable_log_analytics
        log_analytics_workspace_id = var.enable_log_analytics ? azurerm_log_analytics_workspace.cluster[0].id : ""
      }
    }
    aci_connector_linux {
      enabled = false
    }
    azure_policy {
      enabled = var.azure_policy_bool
    }
    http_application_routing {
      enabled = false
    }
    kube_dashboard {
      enabled = false
    }
  }
 
```
Is now managed by:

```
azure_policy_enabled = var.azure_policy_bool#


  azure_active_directory_role_based_access_control {
    managed = var.azure_active_directory_role_based_control
  }

  microsoft_defender {
    log_analytics_workspace_id = var.microsoft_defender_log_id
  }


  dynamic "oms_agent" {
    for_each = var.enable_log_analytics ? [""] : []
    content {
     # enabled                    = var.enable_log_analytics
      log_analytics_workspace_id = var.enable_log_analytics ? azurerm_log_analytics_workspace.cluster[0].id : ""
    }
  }
```
- aci_connector_linux behaviour has changed and is not enabled, same with http_application_routing therefore removed from the TF.
- kube_dashboard is now deprecated under cluster resource and removed
-  TLS upgrade default to 1.2 now
- scale down mode is now a mandatory requirement. Default is ' delete ' therefore changes to ' Deallocate '