### PR TITLE
fix: increase max ml node to 6

### DIFF
--- a/cluster/terraform-jx-boot/vault.tf
+++ b/cluster/terraform-jx-boot/vault.tf
@@ -4,7 +4,7 @@ resource "helm_release" "vault-operator" {
   chart            = "vault-operator"
   namespace        = "jx-vault"
   repository       = "https://kubernetes-charts.banzaicloud.com"
-  version          = "1.14.3"
+  version          = "1.20.0"
   create_namespace = true
 
   set {

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -44,7 +44,7 @@ max_infra_node_count = 6
 use_spot_mlbuild       = true
 mlbuild_node_size      = "Standard_NC4as_T4_v3"
 min_mlbuild_node_count = 0
-max_mlbuild_node_count = 5
+max_mlbuild_node_count = 6
 
 
 # Bot stuff in now in terraform


### PR DESCRIPTION
- We currently are at max ml-nodes (5).
-  due to jx-nbs we need another ml-node as services are not spinning up
- increase max node count to 6
