### PR TITLE
feat: add kubelet client ID to bootjob env vars

### DIFF
--- a/cluster/local.tf
+++ b/cluster/local.tf
@@ -14,15 +14,9 @@ locals {
 
   merged_secrets =  merge(local.registry_secrets)
 
-  #job_secret_env_vars_vault = var.key_vault_enabled ? {
   job_secret_env_vars = var.key_vault_enabled ? {
     AZURE_TENANT_ID       = module.secrets.tenant_id
     AZURE_SUBSCRIPTION_ID = module.secrets.subscription_id
+    AZURE_CLIENT_ID       = module.secrets.client_id
   } : {}
-
-#  job_secret_env_vars_ssa = var.server_side_apply_enabled ? {
-#    KUBECTL_APPLY_FLAGS       = "--server-side --force-conflicts"
-#  } : {}
-
-#  job_secret_env_vars = merge(local.job_secret_env_vars_vault, local.job_secret_env_vars_ssa)
 }

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -146,6 +146,7 @@ module "secrets" {
   source              = "./terraform-jx-azurekeyvault"
   enabled             = var.key_vault_enabled
   principal_id        = module.cluster.kubelet_identity_id
+  kubelet_client_id   = module.cluster.kubelet_client_id
   cluster_name        = local.cluster_name
   resource_group_name = var.key_vault_resource_group_name
   key_vault_name      = var.key_vault_name

--- a/cluster/terraform-jx-azurekeyvault/outputs.tf
+++ b/cluster/terraform-jx-azurekeyvault/outputs.tf
@@ -7,3 +7,6 @@ output "tenant_id" {
 output "subscription_id" {
   value = var.enabled ? data.azurerm_subscription.current.subscription_id : ""
 }
+output "client_id" {
+  value = var.enabled ? var.kubelet_client_id : ""
+}

--- a/cluster/terraform-jx-azurekeyvault/variables.tf
+++ b/cluster/terraform-jx-azurekeyvault/variables.tf
@@ -29,6 +29,10 @@ variable "principal_id" {
   type        = string
   description = "The id of the service principal that should be granted permission on the key vault"
 }
+variable "kubelet_client_id" {
+    type        = string
+    description = "The client id of the kubelet identity used when authenticating to the key vault"
+}
 variable "secret_map" {
   type        = map(string)
   description = "Map of secret keys and values to store in Azure Key Vault"


### PR DESCRIPTION
Adds `AZURE_CLIENT_ID` to the secret `jx-boot-job-env-vars`. This allows use to specify the identity used when attempting to authenticate with azure from the cluster.

Follows from issues with multiple identities existing when trying to populate secrets from initial bootjob.

Relevant PR in jx-land https://github.com/jenkins-x-plugins/secretfacade/pull/20