### PR TITLE
chore: add a prevent destroy on resource

### DIFF
--- a/cluster/terraform-jx-azuredns/main.tf
+++ b/cluster/terraform-jx-azuredns/main.tf
@@ -47,6 +47,10 @@ resource "azurerm_role_assignment" "Give_ExternalDNS_SP_Contributor_Access_to_Re
   scope                = azurerm_resource_group.dns.0.id
   role_definition_name = "DNS Zone Contributor"
   principal_id         = var.principal_id
+  
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "azurerm_role_assignment" "Give_ExternalDNS_SP_Contributor_Access_to_ResourceGroup_to_Apex" {


### PR DESCRIPTION
- This is a temporary fix due to production terraform attempting to destroy the resource. 
- With deployment of NBS environment, a few logical changes needed to be amended on the DNS resources. This was because necessary resources that are not apex integrated were not deploying. 
- The logic was kept the same, besides adding an OR operator for the new dns_resources_enabled flag. When toggled to true, this will aid the deployment of managed DNS resources such as: DNS RG, DNS Zone DNS Records and a SP for external DNS. But maintaining the already developed logic if toggled to false.
```
count = local.enabled && ((local.with_subdomain && var.apex_domain_integration_enabled) || var.dns_resources_enabled) ? 1 : 0
```
- It appears that when applying prod, the SP principle is being destroyed. However, the production SP was managed by the apex integrated resource, which is confusing as it shouldn't have been due to BUILD cluster only enabling this. 
- I moved the resource over to the correct resource group but still attempting to be destroyed. 
- This quick fix will prevent destruction if we need to apply the production terraform at any point. 
- Upon investigating, a few weird things have been noticed which make no sense. Such as the jx3prod-dns-rg being managed by the apex data source? Which is strange as production doesn't meet the criteria as no subdomain and apex_integration_enabled false
```
data "azurerm_resource_group" "apex_resource_group" {
  count = local.enabled && local.with_subdomain && var.apex_domain_integration_enabled ? 1 : 0
  name = var.apex_resource_group_name
}
```
this is in the state:
```
      "module": "module.cluster.module.cluster.module.dns",
      "mode": "data",
      "type": "azurerm_resource_group",
      "name": "apex_dns",
```
however, the names data source does not match up with the data source above. so its confusing to what's going on
- This will be migrated to the mega tf anyway.
