### PR TITLE
fix: reduce min ml build node count 2 -> 0

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -46,7 +46,7 @@ max_infra_node_count = 6
 # MLbuild Node
 use_spot_mlbuild       = true
 mlbuild_node_size      = "Standard_NC4as_T4_v3"
-min_mlbuild_node_count = 2
+min_mlbuild_node_count = 0
 max_mlbuild_node_count = 5
 
 


### PR DESCRIPTION
Got two ml build nodes kicking about with nothing on them. May as well reduce to 0 as we're not using them currently.