### PR TITLE
fix: auto upgrades with conditional logic

### DIFF
--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
 
   automatic_upgrade_channel = var.enable_auto_upgrades ? "patch" : null
 
-  node_os_upgrade_channel = var.enable_auto_upgrades ? "SecurityPatch" : null
+  node_os_upgrade_channel = var.enable_auto_upgrades ? "SecurityPatch" : "None"
 
   dynamic "maintenance_window_node_os" {
     for_each = var.enable_auto_upgrades ? [1] : []

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -9,9 +9,9 @@ resource "azurerm_kubernetes_cluster" "aks" {
   azure_policy_enabled = var.azure_policy_bool
   http_application_routing_enabled = false
 
-  automatic_upgrade_channel = var.enable_auto_upgrades ? "patch" : ""
+  automatic_upgrade_channel = var.enable_auto_upgrades ? "patch" : null
 
-  node_os_upgrade_channel = var.enable_auto_upgrades ? "SecurityPatch" : ""
+  node_os_upgrade_channel = var.enable_auto_upgrades ? "SecurityPatch" : null
 
   dynamic "maintenance_window_node_os" {
     for_each = var.enable_auto_upgrades ? [1] : []


### PR DESCRIPTION
- add conditional logic to the auto upgrade blocks and fix the issues that persisted with the upgrade 
- with new azurerm provider the node os channel will default to ```NodeImage``` change this to ```None``` 