### PR TITLE
test: versions

### DIFF
--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -94,7 +94,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlnode" {
   node_taints           = ["sku=gpu:NoSchedule"]
   node_labels           = { key = "gpu_ready" }
 
-  lifecycle { ignore_changes = [node_taints, node_count, node_labels, orchestrator_version] }
+  lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "buildnode" {
@@ -113,7 +113,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "buildnode" {
   auto_scaling_enabled  = var.max_build_node_count == null ? false : true
   node_taints           = ["sku=build:NoSchedule"]
 
-  lifecycle { ignore_changes = [node_taints, node_count, orchestrator_version] }
+  lifecycle { ignore_changes = [node_taints, node_count] }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "infranode" {
@@ -132,7 +132,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "infranode" {
   auto_scaling_enabled  = var.max_infra_node_count == null ? false : true
   node_taints           = ["sku=infra:NoSchedule"]
 
-  lifecycle { ignore_changes = [node_taints, node_count, orchestrator_version] }
+  lifecycle { ignore_changes = [node_taints, node_count] }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "mlbuildnode" {
@@ -144,13 +144,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlbuildnode" {
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
   vm_size               = var.mlbuild_node_size
   vnet_subnet_id        = var.vnet_subnet_id
-  node_count            = var.use_spot_mlbuild ? 0 : var.mlbuild_node_count
-  min_count             = var.min_mlbuild_node_count
-  max_count             = var.max_mlbuild_node_count
   orchestrator_version  = var.orchestrator_version
   auto_scaling_enabled  = var.max_mlbuild_node_count == null ? false : true
   node_taints           = ["sku=mlbuild:NoSchedule"]
   node_labels           = { key = "gpu_ready" }
 
-  lifecycle { ignore_changes = [node_taints, node_count, node_labels, orchestrator_version] }
+  lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 }

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -90,7 +90,6 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlnode" {
   node_count            = var.use_spot_ml ? 0 : var.ml_node_count
   min_count             = var.min_ml_node_count
   max_count             = var.max_ml_node_count
-  orchestrator_version  = "1.20.7"
   auto_scaling_enabled  = var.max_ml_node_count == null ? false : true
   node_taints           = ["sku=gpu:NoSchedule"]
   node_labels           = { key = "gpu_ready" }

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -90,7 +90,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlnode" {
   node_count            = var.use_spot_ml ? 0 : var.ml_node_count
   min_count             = var.min_ml_node_count
   max_count             = var.max_ml_node_count
-  orchestrator_version  = var.orchestrator_version
+  orchestrator_version  = "1.20.7"
   auto_scaling_enabled  = var.max_ml_node_count == null ? false : true
   node_taints           = ["sku=gpu:NoSchedule"]
   node_labels           = { key = "gpu_ready" }


### PR DESCRIPTION
- ideally ignore_changes would benefit auto_upgrades. But due to our process of manual upgrades, the ignore_changes was blocking the node_pool upgrades. Best way to manage this, as there maybe drift in the versions is the correct population of the orch version and cluster version.