### PR TITLE
chore: increase infra min node count -> 3

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -43,7 +43,7 @@ max_build_node_count = 6
 #Infra Node
 use_spot_infra       = false
 infra_node_size      = "Standard_D8s_v3"
-min_infra_node_count = 2
+min_infra_node_count = 3
 max_infra_node_count = 6
 
 # MLbuild Node


### PR DESCRIPTION
Most our infra is HA w/3 replicas. Makes sense for use to have 3 separate nodes then each replica can be put on a different node.