### PR TITLE
feat: update vm types

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -30,19 +30,19 @@ node_size      = "Standard_D4s_v3"
 
 # Ml nodes
 use_spot_ml       = true
-ml_node_size      = "Standard_NV24s_v3"
+ml_node_size      = "Standard_NV4as_v4"
 min_ml_node_count = 2
 max_ml_node_count = 6
 
 # Build Spot Nodes
 use_spot             = true
-build_node_size      = "Standard_D8s_v4"
+build_node_size      = "Standard_D8s_v6"
 min_build_node_count = 0
 max_build_node_count = 6
 
 #Infra Node
 use_spot_infra       = false
-infra_node_size      = "Standard_D8s_v3"
+infra_node_size      = "Standard_D8s_v6"
 min_infra_node_count = 3
 max_infra_node_count = 6
 

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -26,7 +26,7 @@ enable_auto_upgrades             = true
 # Machines
 min_node_count = 5
 max_node_count = 50
-node_size      = "Standard_D8s_v6"
+node_size      = "Standard_D4s_v6"
 
 # Ml nodes
 use_spot_ml       = true

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -26,11 +26,11 @@ enable_auto_upgrades             = true
 # Machines
 min_node_count = 5
 max_node_count = 50
-node_size      = "Standard_D4s_v3"
+node_size      = "Standard_D8s_v6"
 
 # Ml nodes
 use_spot_ml       = true
-ml_node_size      = "Standard_NV4as_v4"
+ml_node_size      = "Standard_NV24s_v3"
 min_ml_node_count = 2
 max_ml_node_count = 6
 


### PR DESCRIPTION
### Changes
- Build/Infra/Default
  - Move to Standard_D8s_v6/D4s
  - Latest equivilant of what we're already using
  - Similar price per cpu/ram
  
- ML (haven't changed but should)
  - Move to Standard_NV4as_v4
  - **Much** smaller than our current nodes but large enough to handle the workload
  - Currently prod node requests 2.3 cpu & 8.4gb
  - New node has 4 cpu & 14gb ram
  - Old had 24 cpu & 448gb ram (not sure why we ever needed this much 🤷)
  - Need to confirm with Rafay that AMD gpus are okay over NVIDIA Teslas
  - @Reton2 says we need NVIDIA (gpt recommends Standard_NC6s_v3)