### PR TITLE
fix: remove auto upgrade due to version mismatch

### DIFF
--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -26,17 +26,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
     }
   }
 
-  dynamic "maintenance_window_auto_upgrade" {
-    for_each = var.enable_auto_upgrades ? [1] : []
-    content {
-      day_of_week = "Friday"
-      start_time  = "19:00"
-      duration    = 4
-      frequency   = "Weekly"
-      interval    = 1
-    }
-  }
-
   azure_active_directory_role_based_access_control {
     azure_rbac_enabled = false
     tenant_id          = var.tenant_id


### PR DESCRIPTION
- remove k8s automatic versioning. This was a fix to better manage patch versions, however, our control plane has version mismatch compared with the node pools which could be having an impact on state management.