### PR TITLE
fix: no space left on device

### DIFF
--- a/cluster/terraform-jx-boot/vault.tf
+++ b/cluster/terraform-jx-boot/vault.tf
@@ -33,6 +33,6 @@ resource "helm_release" "vault-instance" {
 
   set {
     name = "pvc.size"
-    value = "2Gi"
+    value = "4Gi"
   }
 }


### PR DESCRIPTION
- /dev/nvme0n2            128.0K    128.0K         0 100% /vault/file
- error="open /vault/file/core/cluster/_feature-flags337895877: no space left on device"