### PR TITLE
fix: upgrade az versions and add temp pools for future vm size upgrades

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -8,7 +8,7 @@ terraform {
       version = ">=1.13.3"
     }
     azurerm = {
-      version = ">=3.0.0"
+      version = ">=4.23.0"
     }
   }
 }

--- a/cluster/terraform-jx-azure-storage/main.tf
+++ b/cluster/terraform-jx-azure-storage/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 0.13.2"
   required_providers {
     azurerm = {
-      version = ">=3.0.0"
+      version = ">=4.23.0"
     }
   }
 }

--- a/cluster/terraform-jx-azuredns/main.tf
+++ b/cluster/terraform-jx-azuredns/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=3.0.0"
+      version = ">=4.23.0"
     }
   }
 }

--- a/cluster/terraform-jx-azurekeyvault/main.tf
+++ b/cluster/terraform-jx-azurekeyvault/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=2.99.0"
+      version = ">=4.23.0"
     }
   }
 }

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -82,7 +82,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlnode" {
   auto_scaling_enabled  = var.max_ml_node_count == null ? false : true
   node_taints           = ["sku=gpu:NoSchedule"]
   node_labels           = { key = "gpu_ready" }
-  temporary_name_for_rotation = "tempk8spoolmlnode"
+  temporary_name_for_rotation = "tempml"
 
   lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 }
@@ -102,7 +102,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "buildnode" {
   orchestrator_version  = var.orchestrator_version
   auto_scaling_enabled  = var.max_build_node_count == null ? false : true
   node_taints           = ["sku=build:NoSchedule"]
-  temporary_name_for_rotation = "tempk8spoolbuild"
+  temporary_name_for_rotation = "tempbuild"
 
   lifecycle { ignore_changes = [node_taints, node_count] }
 }
@@ -122,7 +122,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "infranode" {
   orchestrator_version  = var.orchestrator_version
   auto_scaling_enabled  = var.max_infra_node_count == null ? false : true
   node_taints           = ["sku=infra:NoSchedule"]
-  temporary_name_for_rotation = "tempk8spoolinfra"
+  temporary_name_for_rotation = "tempinfra"
 
   lifecycle { ignore_changes = [node_taints, node_count] }
 }
@@ -143,7 +143,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlbuildnode" {
   auto_scaling_enabled  = var.max_mlbuild_node_count == null ? false : true
   node_taints           = ["sku=mlbuild:NoSchedule"]
   node_labels           = { key = "gpu_ready" }
-  temporary_name_for_rotation = "tempk8spoolmlbuild"
+  temporary_name_for_rotation = "tempmlbuild"
 
   lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 }

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -11,8 +11,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
   image_cleaner_interval_hours     = 48
   image_cleaner_enabled            = false
 
-  automatic_upgrade_channel = var.enable_auto_upgrades ? "patch" : null
-
   node_os_upgrade_channel = var.enable_auto_upgrades ? "SecurityPatch" : "None"
 
   dynamic "maintenance_window_node_os" {
@@ -84,6 +82,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlnode" {
   auto_scaling_enabled  = var.max_ml_node_count == null ? false : true
   node_taints           = ["sku=gpu:NoSchedule"]
   node_labels           = { key = "gpu_ready" }
+  temporary_name_for_rotation = "tempk8spoolmlnode"
 
   lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 }
@@ -103,6 +102,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "buildnode" {
   orchestrator_version  = var.orchestrator_version
   auto_scaling_enabled  = var.max_build_node_count == null ? false : true
   node_taints           = ["sku=build:NoSchedule"]
+  temporary_name_for_rotation = "tempk8spoolbuild"
 
   lifecycle { ignore_changes = [node_taints, node_count] }
 }
@@ -122,6 +122,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "infranode" {
   orchestrator_version  = var.orchestrator_version
   auto_scaling_enabled  = var.max_infra_node_count == null ? false : true
   node_taints           = ["sku=infra:NoSchedule"]
+  temporary_name_for_rotation = "tempk8spoolinfra"
 
   lifecycle { ignore_changes = [node_taints, node_count] }
 }
@@ -142,6 +143,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlbuildnode" {
   auto_scaling_enabled  = var.max_mlbuild_node_count == null ? false : true
   node_taints           = ["sku=mlbuild:NoSchedule"]
   node_labels           = { key = "gpu_ready" }
+  temporary_name_for_rotation = "tempk8spoolmlbuild"
 
   lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 }

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=3.0.0"
+      version = ">=4.23.0"
     }
   }
 }

--- a/cluster/terraform-jx-registry-acr-oss/main.tf
+++ b/cluster/terraform-jx-registry-acr-oss/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.3.2"
   required_providers {
     azurerm = {
-      version = ">=3.0.0"
+      version = ">=4.23.0"
     }
   }
 }

--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.3.2"
   required_providers {
     azurerm = {
-      version = ">=3.0.0"
+      version = ">=4.23.0"
     }
   }
 }


### PR DESCRIPTION
- upgrade azure version to keep in line with newest versions
- add a temporary node pool for when we are comfortable with updating in the future. This wasn't available on the previous az version