### PR TITLE
Provision kubesystem nodepool

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -91,6 +91,10 @@ module "cluster" {
   mlbuild_node_count               = var.mlbuild_node_count
   min_mlbuild_node_count           = var.min_mlbuild_node_count
   max_mlbuild_node_count           = var.max_mlbuild_node_count
+  kubesystem_node_size             = var.kubesystem_node_size
+  min_kubesystem_node_count        = var.min_kubesystem_node_count
+  max_kubesystem_node_count        = var.max_kubesystem_node_count
+  kubesystem_node_count            = var.kubesystem_node_count
   subnet_name                      = var.subnet_name
   subnet_cidr                      = var.subnet_cidr
   vnet_cidr                        = var.vnet_cidr

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -144,3 +144,22 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlbuildnode" {
 
   lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 }
+
+resource "azurerm_kubernetes_cluster_node_pool" "kubesystem" {
+  count                 = var.kubesystem_node_size == "" ? 0 : 1
+  name                  = "kubesystemnode"
+  priority              = "Regular"
+  eviction_policy       = "Deallocate"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  vm_size               = var.kubesystem_node_size
+  vnet_subnet_id        = var.vnet_subnet_id
+  orchestrator_version  = var.orchestrator_version
+  node_count            = var.kubesystem_node_count
+  min_count             = var.min_kubesystem_node_count
+  max_count             = var.max_kubesystem_node_count
+  auto_scaling_enabled  = var.max_kubesystem_node_count == null ? false : true
+  mode                  = "System"
+  node_taints           = ["CriticalAddonsOnly=true:NoSchedule"]
+
+  lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
+} 

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -149,7 +149,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "kubesystem" {
   count                 = var.kubesystem_node_size == "" ? 0 : 1
   name                  = "kubesystem"
   priority              = "Regular"
-  eviction_policy       = "Deallocate"
+  eviction_policy       = "Delete"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
   vm_size               = var.kubesystem_node_size
   vnet_subnet_id        = var.vnet_subnet_id
@@ -160,6 +160,10 @@ resource "azurerm_kubernetes_cluster_node_pool" "kubesystem" {
   auto_scaling_enabled  = var.max_kubesystem_node_count == null ? false : true
   mode                  = "System"
   node_taints           = ["CriticalAddonsOnly=true:NoSchedule"]
+
+  node_labels = {
+    "nodepool" = "kubesystem"
+  }
 
   lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 } 

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -147,7 +147,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlbuildnode" {
 
 resource "azurerm_kubernetes_cluster_node_pool" "kubesystem" {
   count                 = var.kubesystem_node_size == "" ? 0 : 1
-  name                  = "kubesystemnode"
+  name                  = "kubesystem"
   priority              = "Regular"
   eviction_policy       = "Deallocate"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id

--- a/cluster/terraform-jx-cluster-aks/cluster/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/variables.tf
@@ -164,6 +164,30 @@ variable "max_mlbuild_node_count" {
 }
 
 // ----------------------------------------------------------------------------
+// kubesystem nodepool variables
+// ----------------------------------------------------------------------------
+variable "kubesystem_node_size" {
+  type        = string
+  default     = ""
+  description = "The size of the kubesystem node to use for the cluster"
+}
+variable "kubesystem_node_count" {
+  description = "The number of kubesystem nodes to use for the cluster"
+  type        = number
+  default     = null
+}
+variable "min_kubesystem_node_count" {
+  description = "The minimum number of kubesystem nodes to use for the cluster if autoscaling is enabled"
+  type        = number
+  default     = null
+}
+variable "max_kubesystem_node_count" {
+  description = "The maximum number of kubesystem nodes to use for the cluster if autoscaling is enabled"
+  type        = number
+  default     = null
+}
+
+// ----------------------------------------------------------------------------
 // Cluster variables
 // ----------------------------------------------------------------------------
 variable "cluster_name" {

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -92,6 +92,10 @@ module "cluster" {
   mlbuild_node_count               = var.mlbuild_node_count
   min_mlbuild_node_count           = var.min_mlbuild_node_count
   max_mlbuild_node_count           = var.max_mlbuild_node_count
+  kubesystem_node_size             = var.kubesystem_node_size
+  min_kubesystem_node_count        = var.min_kubesystem_node_count
+  max_kubesystem_node_count        = var.max_kubesystem_node_count
+  kubesystem_node_count            = var.kubesystem_node_count
   azure_policy_bool                = var.azure_policy_bool
   microsoft_defender_log_id        = var.enable_defender_analytics ? module.cluster.microsoft_defender_log_id : data.azurerm_log_analytics_workspace.microsoft_defender.id
   defender_resource_group          = var.default_suk_bool ? azurerm_resource_group.default_suk[0].name : data.azurerm_resource_group.existing_suk.name

--- a/cluster/terraform-jx-cluster-aks/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/variables.tf
@@ -165,18 +165,6 @@ variable "max_mlbuild_node_count" {
 // ----------------------------------------------------------------------------
 // kubesystem nodepool variables
 // ----------------------------------------------------------------------------
-variable "use_spot_kubesystem" {
-  type        = bool
-  default     = true
-  description = "Should we use spot instances for the kubesystem nodes"
-}
-
-variable "spot_max_price_kubesystem" {
-  type        = number
-  default     = -1
-  description = "The maximum price you're willing to pay in USD per virtual machine, -1 to go to the maximum price"
-}
-
 variable "kubesystem_node_size" {
   type        = string
   default     = ""

--- a/cluster/terraform-jx-cluster-aks/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/variables.tf
@@ -163,6 +163,45 @@ variable "max_mlbuild_node_count" {
 }
 
 // ----------------------------------------------------------------------------
+// kubesystem nodepool variables
+// ----------------------------------------------------------------------------
+variable "use_spot_kubesystem" {
+  type        = bool
+  default     = true
+  description = "Should we use spot instances for the kubesystem nodes"
+}
+
+variable "spot_max_price_kubesystem" {
+  type        = number
+  default     = -1
+  description = "The maximum price you're willing to pay in USD per virtual machine, -1 to go to the maximum price"
+}
+
+variable "kubesystem_node_size" {
+  type        = string
+  default     = ""
+  description = "The size of the kubesystem node to use for the cluster"
+}
+
+variable "kubesystem_node_count" {
+  description = "The number of kubesystem nodes to use for the cluster"
+  type        = number
+  default     = null
+}
+
+variable "min_kubesystem_node_count" {
+  description = "The minimum number of kubesystem nodes to use for the cluster if autoscaling is enabled"
+  type        = number
+  default     = null
+}
+
+variable "max_kubesystem_node_count" {
+  description = "The maximum number of kubesystem nodes to use for the cluster if autoscaling is enabled"
+  type        = number
+  default     = null
+}
+
+// ----------------------------------------------------------------------------
 // Cluster variables
 // ----------------------------------------------------------------------------
 variable "cluster_name" {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -202,6 +202,45 @@ variable "max_mlbuild_node_count" {
 }
 
 // ----------------------------------------------------------------------------
+// kubesystem nodepool variables
+// ----------------------------------------------------------------------------
+variable "use_spot_kubesystem" {
+  type        = bool
+  default     = true
+  description = "Should we use spot instances for the kubesystem nodes"
+}
+
+variable "spot_max_price_kubesystem" {
+  type        = number
+  default     = -1
+  description = "The maximum price you're willing to pay in USD per virtual machine, -1 to go to the maximum price"
+}
+
+variable "kubesystem_node_size" {
+  type        = string
+  default     = ""
+  description = "The size of the kubesystem node to use for the cluster"
+}
+
+variable "kubesystem_node_count" {
+  description = "The number of kubesystem nodes to use for the cluster"
+  type        = number
+  default     = null
+}
+
+variable "min_kubesystem_node_count" {
+  description = "The minimum number of kubesystem nodes to use for the cluster if autoscaling is enabled"
+  type        = number
+  default     = null
+}
+
+variable "max_kubesystem_node_count" {
+  description = "The maximum number of kubesystem nodes to use for the cluster if autoscaling is enabled"
+  type        = number
+  default     = null
+}
+
+// ----------------------------------------------------------------------------
 // Cluster variables
 // ----------------------------------------------------------------------------
 variable "sku_tier" {

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -204,18 +204,6 @@ variable "max_mlbuild_node_count" {
 // ----------------------------------------------------------------------------
 // kubesystem nodepool variables
 // ----------------------------------------------------------------------------
-variable "use_spot_kubesystem" {
-  type        = bool
-  default     = true
-  description = "Should we use spot instances for the kubesystem nodes"
-}
-
-variable "spot_max_price_kubesystem" {
-  type        = number
-  default     = -1
-  description = "The maximum price you're willing to pay in USD per virtual machine, -1 to go to the maximum price"
-}
-
 variable "kubesystem_node_size" {
   type        = string
   default     = ""

--- a/main.tf
+++ b/main.tf
@@ -67,6 +67,10 @@ module "cluster" {
   mlbuild_node_count                   = var.mlbuild_node_count
   min_mlbuild_node_count               = var.min_mlbuild_node_count
   max_mlbuild_node_count               = var.max_mlbuild_node_count
+  kubesystem_node_size                 = var.kubesystem_node_size
+  min_kubesystem_node_count            = var.min_kubesystem_node_count
+  max_kubesystem_node_count            = var.max_kubesystem_node_count
+  kubesystem_node_count                = var.kubesystem_node_count
   storage_resource_group_name          = var.storage_resource_group_name
   subnet_cidr                          = var.subnet_cidr
   subnet_name                          = var.subnet_name

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -29,7 +29,7 @@ max_node_count = 50
 node_size      = "Standard_D16s_v6"
 
 # Kubesystem
-kubesystem_node_size      = "Standard_D16s_v3"
+kubesystem_node_size      = "Standard_D8s_v4"
 min_kubesystem_node_count = 2
 max_kubesystem_node_count = 6
 

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -28,6 +28,11 @@ min_node_count = 5
 max_node_count = 50
 node_size      = "Standard_D16s_v6"
 
+# Kubesystem
+kubesystem_node_size      = "Standard_D16s_v3"
+min_kubesystem_node_count = 2
+max_kubesystem_node_count = 6
+
 # Ml nodes
 use_spot_ml       = true
 ml_node_size      = "Standard_NV24s_v3"

--- a/variables.tf
+++ b/variables.tf
@@ -204,6 +204,33 @@ variable "max_mlbuild_node_count" {
 }
 
 // ----------------------------------------------------------------------------
+// kubesystem nodepool variables
+// ----------------------------------------------------------------------------
+variable "kubesystem_node_size" {
+  type        = string
+  default     = ""
+  description = "The size of the kubesystem node to use for the cluster"
+}
+
+variable "kubesystem_node_count" {
+  description = "The number of kubesystem nodes to use for the cluster"
+  type        = number
+  default     = null
+}
+
+variable "min_kubesystem_node_count" {
+  description = "The minimum number of kubesystem nodes to use for the cluster if autoscaling is enabled"
+  type        = number
+  default     = null
+}
+
+variable "max_kubesystem_node_count" {
+  description = "The maximum number of kubesystem nodes to use for the cluster if autoscaling is enabled"
+  type        = number
+  default     = null
+}
+
+// ----------------------------------------------------------------------------
 // Cluster variables
 // ----------------------------------------------------------------------------
 variable "sku_tier" {


### PR DESCRIPTION
- kubesystem node pool creation
- This node pool will host kubesystem services such as coredns
- this node pool will not be on spot as high priority nodes to run coredns efficiently with a min of 2 replicas and max 6 (incase scaling is necessary). 
- node_taints = ["CriticalAddonsOnly=true:NoSchedule"] added to make sure no other applications/services get scheduled to this node

The next step is to make sure that cordedns gets assigned to the kubesystem node pool. This is the difficult part as AKS manage coredns. 

There is nothing in TF which declares how to amend / manage the deployment. So from what I have researched so far, the only method is to manually amend the deployment manifest for cordns to add:

```
nodeSelector:
        nodepool: kubesystem
```