### PR TITLE
feat: upgrade build and infra node pools

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -36,13 +36,13 @@ max_ml_node_count = 6
 
 # Build Spot Nodes
 use_spot             = true
-build_node_size      = "Standard_D8s_v4"
+build_node_size      = "Standard_D8s_v5"
 min_build_node_count = 0
 max_build_node_count = 6
 
 #Infra Node
 use_spot_infra       = false
-infra_node_size      = "Standard_D8s_v3"
+infra_node_size      = "Standard_D8s_v5"
 min_infra_node_count = 3
 max_infra_node_count = 6
 


### PR DESCRIPTION
- Standard_D8s_v5 has been tested on our default node pool and stability has been brought back to our lovely cluster.
- Upgrading build and infra nodes to same vm size and version