### PR TITLE
feat: amend logic for defender resources

### DIFF
--- a/cluster/terraform-jx-cluster-aks/local.tf
+++ b/cluster/terraform-jx-cluster-aks/local.tf
@@ -5,4 +5,6 @@ locals {
   cluster_node_resource_group_name = var.cluster_node_resource_group_name != "" ? var.cluster_node_resource_group_name : "rg-cluster-node-${join("", regexall("[A-Za-z0-9\\-_().]", var.cluster_name))}"
   network_name                     = var.network_name != "" ? var.network_name : join("", regexall("[A-Za-z0-9\\-_.]", var.cluster_name))
   subnet_name                      = var.subnet_name != "" ? var.subnet_name : join("", regexall("[A-Za-z0-9\\-_.]", var.cluster_name))
+  microsoft_defender_log_id        = var.enable_defender_analytics ? (var.default_suk_bool ? module.cluster.microsoft_defender_log_id : data.azurerm_log_analytics_workspace.microsoft_defender.id) : null
+  defender_resource_group_name     = (var.default_suk_bool ? azurerm_resource_group.default_suk[0].name : data.azurerm_resource_group.existing_suk[0].name)
 }

--- a/cluster/terraform-jx-cluster-aks/local.tf
+++ b/cluster/terraform-jx-cluster-aks/local.tf
@@ -5,6 +5,11 @@ locals {
   cluster_node_resource_group_name = var.cluster_node_resource_group_name != "" ? var.cluster_node_resource_group_name : "rg-cluster-node-${join("", regexall("[A-Za-z0-9\\-_().]", var.cluster_name))}"
   network_name                     = var.network_name != "" ? var.network_name : join("", regexall("[A-Za-z0-9\\-_.]", var.cluster_name))
   subnet_name                      = var.subnet_name != "" ? var.subnet_name : join("", regexall("[A-Za-z0-9\\-_.]", var.cluster_name))
-  microsoft_defender_log_id        = var.enable_defender_analytics ? (var.default_suk_bool ? module.cluster.microsoft_defender_log_id : data.azurerm_log_analytics_workspace.microsoft_defender.id) : null
-  defender_resource_group_name     = (var.default_suk_bool ? azurerm_resource_group.default_suk[0].name : data.azurerm_resource_group.existing_suk[0].name)
+  microsoft_defender_log_id = var.enable_defender_analytics ? (
+    var.default_suk_bool ? module.cluster.microsoft_defender_log_id : data.azurerm_log_analytics_workspace.microsoft_defender[0].id
+  ) : null
+
+  defender_resource_group_name = (
+    var.default_suk_bool ? azurerm_resource_group.default_suk[0].name : data.azurerm_resource_group.existing_suk[0].name
+  )
 }

--- a/cluster/terraform-jx-cluster-aks/local.tf
+++ b/cluster/terraform-jx-cluster-aks/local.tf
@@ -5,11 +5,6 @@ locals {
   cluster_node_resource_group_name = var.cluster_node_resource_group_name != "" ? var.cluster_node_resource_group_name : "rg-cluster-node-${join("", regexall("[A-Za-z0-9\\-_().]", var.cluster_name))}"
   network_name                     = var.network_name != "" ? var.network_name : join("", regexall("[A-Za-z0-9\\-_.]", var.cluster_name))
   subnet_name                      = var.subnet_name != "" ? var.subnet_name : join("", regexall("[A-Za-z0-9\\-_.]", var.cluster_name))
-  microsoft_defender_log_id = var.enable_defender_analytics ? (
-    var.default_suk_bool ? module.cluster.microsoft_defender_log_id : data.azurerm_log_analytics_workspace.microsoft_defender[0].id
-  ) : null
-
-  defender_resource_group_name = (
-    var.default_suk_bool ? azurerm_resource_group.default_suk[0].name : data.azurerm_resource_group.existing_suk[0].name
-  )
+  microsoft_defender_log_id        = var.enable_defender_analytics ? (var.default_suk_bool ? module.cluster.microsoft_defender_log_id : data.azurerm_log_analytics_workspace.microsoft_defender[0].id) : null
+  defender_resource_group_name     = (var.default_suk_bool ? azurerm_resource_group.default_suk[0].name : data.azurerm_resource_group.existing_suk[0].name)
 }

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -22,6 +22,7 @@ data "azurerm_subscription" "current" {
 // ----------------------------------------------------------------------------
 
 data "azurerm_resource_group" "existing_suk" {
+  count = var.default_suk_bool ? 0 : 1
   name = var.default_rg
 }
 

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -27,7 +27,8 @@ data "azurerm_resource_group" "existing_suk" {
 }
 
 data "azurerm_log_analytics_workspace" "microsoft_defender" {
-  name = var.microsoft_defender_log_analytics_name
+  count               = var.enable_defender_analytics ? 0 : 1
+  name                = var.microsoft_defender_log_analytics_name
   resource_group_name = var.default_rg
 }
 

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -27,7 +27,7 @@ data "azurerm_resource_group" "existing_suk" {
 }
 
 data "azurerm_log_analytics_workspace" "microsoft_defender" {
-  count               = var.enable_defender_analytics ? 0 : 1
+  count               = var.enable_defender_analytics && !var.default_suk_bool ? 1 : 0
   name                = var.microsoft_defender_log_analytics_name
   resource_group_name = var.default_rg
 }

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -93,8 +93,8 @@ module "cluster" {
   min_mlbuild_node_count           = var.min_mlbuild_node_count
   max_mlbuild_node_count           = var.max_mlbuild_node_count
   azure_policy_bool                = var.azure_policy_bool
-  microsoft_defender_log_id        = var.enable_defender_analytics ? module.cluster.microsoft_defender_log_id : data.azurerm_log_analytics_workspace.microsoft_defender.id
-  defender_resource_group          = var.default_suk_bool ? azurerm_resource_group.default_suk[0].name : data.azurerm_resource_group.existing_suk.name
+  microsoft_defender_log_id        = local.microsoft_defender_log_id
+  defender_resource_group          = local.defender_resource_group_name
   enable_defender_analytics        = var.enable_defender_analytics
   tenant_id                        = data.azurerm_subscription.current.tenant_id
   orchestrator_version             = var.orchestrator_version


### PR DESCRIPTION
- unfortunately, even though the original conditional logic worked with NBS. It does not with monbs.
- Here I have amended the conditional and count logic on the resources.
- With the use of a toggle, when set to true, it will go ahead and create the resource and pass in the correct log_id and resource name from either the data object (terraform-jx azure instance) OR the resource object (SaaS instance).
- If set to false, it continues to use the data object

This has been tested on terraform-nbs and doesn't make any changes. And no changes in this pr.