### PR TITLE
feat: add new node label to infra nodes

### DIFF
--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -66,82 +66,83 @@ resource "azurerm_kubernetes_cluster" "aks" {
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "mlnode" {
-  count                       = var.ml_node_size == "" ? 0 : 1
-  name                        = "mlnode"
-  priority                    = var.use_spot_ml ? "Spot" : "Regular"
-  eviction_policy             = var.use_spot_ml ? "Deallocate" : null
-  spot_max_price              = var.use_spot_ml ? var.spot_max_price_ml : null
-  kubernetes_cluster_id       = azurerm_kubernetes_cluster.aks.id
-  vm_size                     = var.ml_node_size
-  vnet_subnet_id              = var.vnet_subnet_id
-  node_count                  = var.use_spot_ml ? 0 : var.ml_node_count
-  min_count                   = var.min_ml_node_count
-  max_count                   = var.max_ml_node_count
-  orchestrator_version        = var.orchestrator_version
-  auto_scaling_enabled        = var.max_ml_node_count == null ? false : true
-  node_taints                 = ["sku=gpu:NoSchedule"]
-  node_labels                 = { key = "gpu_ready" }
+  count                 = var.ml_node_size == "" ? 0 : 1
+  name                  = "mlnode"
+  priority              = var.use_spot_ml ? "Spot" : "Regular"
+  eviction_policy       = var.use_spot_ml ? "Deallocate" : null
+  spot_max_price        = var.use_spot_ml ? var.spot_max_price_ml : null
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  vm_size               = var.ml_node_size
+  vnet_subnet_id        = var.vnet_subnet_id
+  node_count            = var.use_spot_ml ? 0 : var.ml_node_count
+  min_count             = var.min_ml_node_count
+  max_count             = var.max_ml_node_count
+  orchestrator_version  = var.orchestrator_version
+  auto_scaling_enabled  = var.max_ml_node_count == null ? false : true
+  node_taints           = ["sku=gpu:NoSchedule"]
+  node_labels           = { key = "gpu_ready" }
   temporary_name_for_rotation = "tempml"
 
   lifecycle { ignore_changes = [node_taints, node_count, node_labels] }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "buildnode" {
-  count                       = var.build_node_size == "" ? 0 : 1
-  name                        = "buildnode"
-  priority                    = var.use_spot ? "Spot" : "Regular"
-  eviction_policy             = var.use_spot ? "Deallocate" : null
-  spot_max_price              = var.use_spot ? var.spot_max_price : null
-  kubernetes_cluster_id       = azurerm_kubernetes_cluster.aks.id
-  vm_size                     = var.build_node_size
-  vnet_subnet_id              = var.vnet_subnet_id
-  node_count                  = var.use_spot ? 0 : var.build_node_count
-  min_count                   = var.min_build_node_count
-  max_count                   = var.max_build_node_count
-  orchestrator_version        = var.orchestrator_version
-  auto_scaling_enabled        = var.max_build_node_count == null ? false : true
-  node_taints                 = ["sku=build:NoSchedule"]
+  count                 = var.build_node_size == "" ? 0 : 1
+  name                  = "buildnode"
+  priority              = var.use_spot ? "Spot" : "Regular"
+  eviction_policy       = var.use_spot ? "Deallocate" : null
+  spot_max_price        = var.use_spot ? var.spot_max_price : null
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  vm_size               = var.build_node_size
+  vnet_subnet_id        = var.vnet_subnet_id
+  node_count            = var.use_spot ? 0 : var.build_node_count
+  min_count             = var.min_build_node_count
+  max_count             = var.max_build_node_count
+  orchestrator_version  = var.orchestrator_version
+  auto_scaling_enabled  = var.max_build_node_count == null ? false : true
+  node_taints           = ["sku=build:NoSchedule"]
   temporary_name_for_rotation = "tempbuild"
 
   lifecycle { ignore_changes = [node_taints, node_count] }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "infranode" {
-  count                       = var.infra_node_size == "" ? 0 : 1
-  name                        = "infranode"
-  priority                    = var.use_spot_infra ? "Spot" : "Regular"
-  eviction_policy             = var.use_spot_infra ? "Deallocate" : null
-  spot_max_price              = var.use_spot_infra ? var.spot_max_price_infra : null
-  kubernetes_cluster_id       = azurerm_kubernetes_cluster.aks.id
-  vm_size                     = var.infra_node_size
-  vnet_subnet_id              = var.vnet_subnet_id
-  node_count                  = var.use_spot_infra ? 0 : var.infra_node_count
-  min_count                   = var.min_infra_node_count
-  max_count                   = var.max_infra_node_count
-  orchestrator_version        = var.orchestrator_version
-  auto_scaling_enabled        = var.max_infra_node_count == null ? false : true
-  node_taints                 = ["sku=infra:NoSchedule"]
+  count                 = var.infra_node_size == "" ? 0 : 1
+  name                  = "infranode"
+  priority              = var.use_spot_infra ? "Spot" : "Regular"
+  eviction_policy       = var.use_spot_infra ? "Deallocate" : null
+  spot_max_price        = var.use_spot_infra ? var.spot_max_price_infra : null
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  vm_size               = var.infra_node_size
+  vnet_subnet_id        = var.vnet_subnet_id
+  node_count            = var.use_spot_infra ? 0 : var.infra_node_count
+  min_count             = var.min_infra_node_count
+  max_count             = var.max_infra_node_count
+  orchestrator_version  = var.orchestrator_version
+  auto_scaling_enabled  = var.max_infra_node_count == null ? false : true
+  node_taints           = ["sku=infra:NoSchedule"]
+  node_labels = { environment = "infra" }
   temporary_name_for_rotation = "tempinfra"
 
   lifecycle { ignore_changes = [node_taints, node_count] }
 }
 
 resource "azurerm_kubernetes_cluster_node_pool" "mlbuildnode" {
-  count                       = var.mlbuild_node_size == "" ? 0 : 1
-  name                        = "mlbuildnode"
-  priority                    = var.use_spot_mlbuild ? "Spot" : "Regular"
-  eviction_policy             = var.use_spot_mlbuild ? "Deallocate" : null
-  spot_max_price              = var.use_spot_mlbuild ? var.spot_max_price_mlbuild : null
-  kubernetes_cluster_id       = azurerm_kubernetes_cluster.aks.id
-  vm_size                     = var.mlbuild_node_size
-  vnet_subnet_id              = var.vnet_subnet_id
-  orchestrator_version        = var.orchestrator_version
-  node_count                  = var.use_spot_mlbuild ? 0 : var.mlbuild_node_count
-  min_count                   = var.min_mlbuild_node_count
-  max_count                   = var.max_mlbuild_node_count
-  auto_scaling_enabled        = var.max_mlbuild_node_count == null ? false : true
-  node_taints                 = ["sku=mlbuild:NoSchedule"]
-  node_labels                 = { key = "gpu_ready" }
+  count                 = var.mlbuild_node_size == "" ? 0 : 1
+  name                  = "mlbuildnode"
+  priority              = var.use_spot_mlbuild ? "Spot" : "Regular"
+  eviction_policy       = var.use_spot_mlbuild ? "Deallocate" : null
+  spot_max_price        = var.use_spot_mlbuild ? var.spot_max_price_mlbuild : null
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.aks.id
+  vm_size               = var.mlbuild_node_size
+  vnet_subnet_id        = var.vnet_subnet_id
+  orchestrator_version  = var.orchestrator_version
+  node_count            = var.use_spot_mlbuild ? 0 : var.mlbuild_node_count
+  min_count             = var.min_mlbuild_node_count
+  max_count             = var.max_mlbuild_node_count
+  auto_scaling_enabled  = var.max_mlbuild_node_count == null ? false : true
+  node_taints           = ["sku=mlbuild:NoSchedule"]
+  node_labels           = { key = "gpu_ready" }
   temporary_name_for_rotation = "tempmlbuild"
 
   lifecycle { ignore_changes = [node_taints, node_count, node_labels] }

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -121,7 +121,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "infranode" {
   orchestrator_version  = var.orchestrator_version
   auto_scaling_enabled  = var.max_infra_node_count == null ? false : true
   node_taints           = ["sku=infra:NoSchedule"]
-  node_labels = { environment = "infra" }
+  node_labels = { node = "infra" }
   temporary_name_for_rotation = "tempinfra"
 
   lifecycle { ignore_changes = [node_taints, node_count] }


### PR DESCRIPTION
- add new node label to the infra node pools. This will aid k8s vm size upgrades due to this label being added to the temp node pool.
- We currently define the nodeSelector as the agent pool, which is the name of the node. When running upgrades services dependent on this node pool can not migrate to the temp node pool