### PR TITLE
feat: add flag for toggling AKS cost analysis

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -95,6 +95,7 @@ module "cluster" {
   subnet_cidr                           = var.subnet_cidr
   vnet_cidr                             = var.vnet_cidr
   azure_policy_bool                     = var.azure_policy_bool
+  cost_analysis_bool                    = var.cost_analysis_bool
   microsoft_defender_log_id             = module.cluster.microsoft_defender_log_id
   default_suk_bool                      = var.default_suk_bool
   enable_defender_analytics             = var.enable_defender_analytics

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -7,6 +7,7 @@ resource "azurerm_kubernetes_cluster" "aks" {
   dns_prefix                       = var.dns_prefix
   kubernetes_version               = var.cluster_version
   azure_policy_enabled             = var.azure_policy_bool
+  cost_analysis_enabled            = var.cost_analysis_bool
   http_application_routing_enabled = false
   image_cleaner_interval_hours     = 48
   image_cleaner_enabled            = false

--- a/cluster/terraform-jx-cluster-aks/cluster/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/variables.tf
@@ -217,6 +217,10 @@ variable "azure_policy_bool" {
   type = bool
 }
 
+variable "cost_analysis_bool" {
+  type = bool
+}
+
 variable "microsoft_defender_log_analytics_name" {
   type = string
 }

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -89,6 +89,7 @@ module "cluster" {
   min_mlbuild_node_count                = var.min_mlbuild_node_count
   max_mlbuild_node_count                = var.max_mlbuild_node_count
   azure_policy_bool                     = var.azure_policy_bool
+  cost_analysis_bool                    = var.cost_analysis_bool
   microsoft_defender_log_id             = module.cluster.microsoft_defender_log_id
   defender_resource_group               = local.defender_resource_group_name
   enable_defender_analytics             = var.enable_defender_analytics

--- a/cluster/terraform-jx-cluster-aks/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/variables.tf
@@ -235,6 +235,10 @@ variable "azure_policy_bool" {
   type = bool
 }
 
+variable "cost_analysis_bool" {
+  type = bool
+}
+
 variable "microsoft_defender_log_id" {
   type = string
 }

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -270,6 +270,12 @@ variable "enable_log_analytics" {
   default     = false
   description = "Flag to indicate whether to enable Log Analytics integration for cluster"
 }
+
+variable "cost_analysis_bool" {
+  type        = bool
+  default     = false
+  description = "Flag to indicate whether to enable cost analysis for cluster"
+}
 variable "logging_retention_days" {
   type        = number
   default     = 30

--- a/main.tf
+++ b/main.tf
@@ -72,6 +72,7 @@ module "cluster" {
   subnet_name                           = var.subnet_name
   vnet_cidr                             = var.vnet_cidr
   azure_policy_bool                     = var.azure_policy_bool
+  cost_analysis_bool                    = var.cost_analysis_bool
   acr_enabled                           = var.acr_enabled
   install_kuberhealthy                  = var.install_kuberhealthy
   dns_resources_enabled                 = var.dns_resources_enabled

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -16,6 +16,7 @@ key_vault_name                   = "k8secrets-vault"
 cluster_version                  = "1.31.6"
 orchestrator_version             = "1.31.6"
 azure_policy_bool                = false
+cost_analysis_bool               = false
 acr_enabled                      = true
 install_kuberhealthy             = true
 dns_resources_enabled            = true

--- a/variables.tf
+++ b/variables.tf
@@ -282,6 +282,12 @@ variable "azure_policy_bool" {
   type = bool
 }
 
+variable "cost_analysis_bool" {
+  type = bool
+  default = false
+  description = "Flag to indicate whether to enable cost analysis for the cluster"
+}
+
 // ----------------------------------------------------------------------------
 // DNS variables
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add flag to enable granular cluster cost analysis with `ost_analysis_enabled` argument https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/kubernetes_cluster#cost_analysis_enabled-1