### PR TITLE
feat: deploy new ACR cache rule for registry-1.docker-io/*

### DIFF
--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -56,3 +56,12 @@ resource "azurerm_container_registry_cache_rule" "cache_rule" {
   source_repo           = "docker.io/*"
   credential_set_id     = "${azurerm_container_registry.acr[0].id}/credentialSets/dockerhub-cred"
 }
+
+resource "azurerm_container_registry_cache_rule" "cache_rule_bitnami" {
+  count                 = var.acr_enabled && var.external_registry_url == "" && var.use_existing_acr_name == null ? 1 : 0
+  name                  = "registry-1-docker-io"
+  container_registry_id = azurerm_container_registry.acr[0].id
+  target_repo           = "registry-1.docker-io/*"
+  source_repo           = "registry-1.docker.io/*"
+  credential_set_id     = "${azurerm_container_registry.acr[0].id}/credentialSets/dockerhub-cred"
+}

--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -57,9 +57,9 @@ resource "azurerm_container_registry_cache_rule" "cache_rule" {
   credential_set_id     = "${azurerm_container_registry.acr[0].id}/credentialSets/dockerhub-cred"
 }
 
-resource "azurerm_container_registry_cache_rule" "cache_rule_bitnami" {
+resource "azurerm_container_registry_cache_rule" "cache_rule_bitnami_charts" {
   count                 = var.acr_enabled && var.external_registry_url == "" && var.use_existing_acr_name == null ? 1 : 0
-  name                  = "registry-1-docker-io"
+  name                  = "bitnami-helm-charts"
   container_registry_id = azurerm_container_registry.acr[0].id
   target_repo           = "registry-1.docker-io/*"
   source_repo           = "registry-1.docker.io/*"


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
bitnami helm charts are _not_ being cached via ACR currently as they are not stored via `docker.io/*`

Instead, they use `registry-1.docker-io/*`, meaning the pullthrough rule is ignored, and the chart OCI artifacts are rate-limited by docker hub.

This change adds an explicit cache rule for `registry-1.docker-io/*`

## Changes Made
- [X] New resources added
- [ ] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.