### PR TITLE
revert: acr bitnami cache rule

### DIFF
--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -56,12 +56,3 @@ resource "azurerm_container_registry_cache_rule" "cache_rule" {
   source_repo           = "docker.io/*"
   credential_set_id     = "${azurerm_container_registry.acr[0].id}/credentialSets/dockerhub-cred"
 }
-
-resource "azurerm_container_registry_cache_rule" "cache_rule_bitnami_charts" {
-  count                 = var.acr_enabled && var.external_registry_url == "" && var.use_existing_acr_name == null ? 1 : 0
-  name                  = "bitnami-helm-charts"
-  container_registry_id = azurerm_container_registry.acr[0].id
-  target_repo           = "registry-1.docker-io/*"
-  source_repo           = "registry-1.docker.io/*"
-  credential_set_id     = "${azurerm_container_registry.acr[0].id}/credentialSets/dockerhub-cred"
-}


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Revert change as ACR pull-through caching only applies to "public" docker repos

## Changes Made
- [ ] New resources added
- [ ] Existing resources modified
- [ ] Resources deleted
- [X] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.