### PR TITLE
feat: create token for ACR access; pass to JX boot env vars

### DIFF
--- a/cluster/local.tf
+++ b/cluster/local.tf
@@ -15,8 +15,13 @@ locals {
   merged_secrets = merge(local.registry_secrets)
 
   job_secret_env_vars = var.key_vault_enabled ? {
-    AZURE_TENANT_ID       = module.secrets.tenant_id
-    AZURE_SUBSCRIPTION_ID = module.secrets.subscription_id
-    AZURE_CLIENT_ID       = module.secrets.client_id
-  } : {}
+    AZURE_TENANT_ID        = module.secrets.tenant_id
+    AZURE_SUBSCRIPTION_ID  = module.secrets.subscription_id
+    AZURE_CLIENT_ID        = module.secrets.client_id
+    JX_REPOSITORY_USERNAME = module.registry.registry_token_name
+    JX_REPOSITORY_PASSWORD = module.registry.registry_token_password
+  } : {
+    JX_REPOSITORY_USERNAME = module.registry.registry_token_name
+    JX_REPOSITORY_PASSWORD = module.registry.registry_token_password
+  }
 }

--- a/cluster/terraform-jx-registry-acr/local.tf
+++ b/cluster/terraform-jx-registry-acr/local.tf
@@ -1,4 +1,6 @@
 locals {
   resource_group_name     = var.resource_group_name != "" ? var.resource_group_name : "rg-registry-${join("", regexall("[A-Za-z0-9\\-_().]", var.cluster_name))}"
   container_registry_name = var.container_registry_name != "" ? var.container_registry_name : substr(join("", regexall("[A-Za-z0-9]", var.cluster_name)), 0, 45)
+  container_registry_token_name = var.container_registry_token_name != "" ? var.container_registry_token_name : "token-${substr(join("", regexall("[A-Za-z0-9]", var.cluster_name)), 0, 38)}"
+  container_registry_scope_map_name = var.container_registry_scope_map_name != "" ? var.container_registry_scope_map_name : "scope-map-${substr(join("", regexall("[A-Za-z0-9]", var.cluster_name)), 0, 33)}"
 }

--- a/cluster/terraform-jx-registry-acr/outputs.tf
+++ b/cluster/terraform-jx-registry-acr/outputs.tf
@@ -19,5 +19,5 @@ output "registry_token_name" {
 }
 
 output "registry_token_password" {
-  value = var.external_registry_url != "" ? "" : (var.use_existing_acr_name == null && length(azurerm_container_registry.acr) > 0 ? azurerm_container_registry_token_password.acr_registry_token_password.password1 : "")
+  value = var.external_registry_url != "" ? "" : (var.use_existing_acr_name == null && length(azurerm_container_registry.acr) > 0 ? tostring(azurerm_container_registry_token_password.acr_registry_token_password.password1[0]) : "")
 }

--- a/cluster/terraform-jx-registry-acr/outputs.tf
+++ b/cluster/terraform-jx-registry-acr/outputs.tf
@@ -16,8 +16,10 @@ output "resource_group_name" {
 
 output "registry_token_name" {
   value = var.external_registry_url != "" ? "" : (var.use_existing_acr_name == null && length(azurerm_container_registry.acr) > 0 ? azurerm_container_registry_token.acr_registry_token.name : "")
+  sensitive = true
 }
 
 output "registry_token_password" {
-  value = var.external_registry_url != "" ? "" : (var.use_existing_acr_name == null && length(azurerm_container_registry.acr) > 0 ? tostring(azurerm_container_registry_token_password.acr_registry_token_password.password1[0]) : "")
+  value = var.external_registry_url != "" ? "" : (var.use_existing_acr_name == null && length(azurerm_container_registry.acr) > 0 ? azurerm_container_registry_token_password.acr_registry_token_password.password1[0].value : "")
+  sensitive = true
 }

--- a/cluster/terraform-jx-registry-acr/outputs.tf
+++ b/cluster/terraform-jx-registry-acr/outputs.tf
@@ -13,3 +13,11 @@ output "admin_password" {
 output "resource_group_name" {
   value = var.external_registry_url != "" ? "" : (var.use_existing_acr_resource_group_name == null && length(azurerm_container_registry.acr) > 0 ? azurerm_container_registry.acr[0].resource_group_name : (length(data.azurerm_container_registry.acr_existing) > 0 ? data.azurerm_container_registry.acr_existing[0].resource_group_name : ""))
 }
+
+output "registry_token_name" {
+  value = var.external_registry_url != "" ? "" : (var.use_existing_acr_name == null && length(azurerm_container_registry.acr) > 0 ? azurerm_container_registry_token.acr_registry_token.name : "")
+}
+
+output "registry_token_password" {
+  value = var.external_registry_url != "" ? "" : (var.use_existing_acr_name == null && length(azurerm_container_registry.acr) > 0 ? azurerm_container_registry_token_password.acr_registry_token_password.password1 : "")
+}

--- a/cluster/terraform-jx-registry-acr/variables.tf
+++ b/cluster/terraform-jx-registry-acr/variables.tf
@@ -11,6 +11,16 @@ variable "container_registry_name" {
   type        = string
   default     = ""
 }
+variable "container_registry_scope_map_name" {
+  description = "Name of container registry scope map"
+  type        = string
+  default     = ""
+}
+variable "container_registry_token_name" {
+  description = "Name of container registry token"
+  type        = string
+  default     = ""
+}
 variable "resource_group_name" {
   description = "Resource group in which to create registry"
   type        = string


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Add authentication token to ACR and pass the token credentials as environment variables to JX boot as `JX_REPOSITORY_USERNAME` and `JX_REPOSITORY_PASSWORD`.

When set, these env vars allow JX to ause ACR as an OCI registry for helm charts

## Changes Made
- [X] New resources added
- [ ] Existing resources modified
- [ ] Resources deleted
- [X] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.