### PR TITLE
feat: create OSS ACR token and pass env vars to JX boot

### DIFF
--- a/cluster/local.tf
+++ b/cluster/local.tf
@@ -19,7 +19,7 @@ locals {
     AZURE_SUBSCRIPTION_ID = module.secrets.subscription_id
     AZURE_CLIENT_ID       = module.secrets.client_id
   } : {
-    JX_REPOSITORY_USERNAME = module.oss_registry.oss_token_name
-    JX_REPOSITORY_PASSWORD = module.oss_registry.oss_token_password
+    JX_REPOSITORY_USERNAME = module.oss_registry[0].oss_token_name
+    JX_REPOSITORY_PASSWORD = module.oss_registry[0].oss_token_password
   }
 }

--- a/cluster/local.tf
+++ b/cluster/local.tf
@@ -18,5 +18,7 @@ locals {
     AZURE_TENANT_ID       = module.secrets.tenant_id
     AZURE_SUBSCRIPTION_ID = module.secrets.subscription_id
     AZURE_CLIENT_ID       = module.secrets.client_id
+    JX_REPOSITORY_USERNAME = module.oss_registry.oss_token_name
+    JX_REPOSITORY_PASSWORD = module.oss_registry.oss_token_password
   } : {}
 }

--- a/cluster/local.tf
+++ b/cluster/local.tf
@@ -18,7 +18,8 @@ locals {
     AZURE_TENANT_ID       = module.secrets.tenant_id
     AZURE_SUBSCRIPTION_ID = module.secrets.subscription_id
     AZURE_CLIENT_ID       = module.secrets.client_id
+  } : {
     JX_REPOSITORY_USERNAME = module.oss_registry.oss_token_name
     JX_REPOSITORY_PASSWORD = module.oss_registry.oss_token_password
-  } : {}
+  }
 }

--- a/cluster/terraform-jx-registry-acr-oss/local.tf
+++ b/cluster/terraform-jx-registry-acr-oss/local.tf
@@ -2,4 +2,6 @@ locals {
   anonymous_pull_enabled  = true
   admin_enabled           = true
   AcrPush_definition_name = "AcrPush"
+  oss_registry_token_name = var.oss_registry_token_name != "" ? var.oss_registry_token_name : "token-${substr(join("", regexall("[A-Za-z0-9]", "mqube-oss")), 0, 38)}"
+  oss_registry_scope_map_name = var.oss_registry_scope_map_name != "" ? var.oss_registry_scope_map_name : "scope-map-${substr(join("", regexall("[A-Za-z0-9]", "mqube-oss")), 0, 33)}"
 }

--- a/cluster/terraform-jx-registry-acr-oss/main.tf
+++ b/cluster/terraform-jx-registry-acr-oss/main.tf
@@ -25,3 +25,30 @@ resource "azurerm_role_assignment" "oss_push" {
   role_definition_name = local.AcrPush_definition_name
   principal_id         = var.principal_id
 }
+
+resource "azurerm_container_registry_scope_map" "oss_scope_map" {
+  name                    = local.oss_registry_scope_map_name
+  container_registry_name = var.oss_registry_name
+  resource_group_name     = var.resource_group_name
+  actions = [
+    "metadata/read",
+    "metadata/write",
+    "content/read",
+    "content/write",
+    "content/delete"
+  ]
+}
+
+resource "azurerm_container_registry_token" "oss_registry_token" {
+  name                    = local.oss_registry_token_name
+  container_registry_name = var.oss_registry_name
+  resource_group_name     = var.resource_group_name
+  scope_map_id            = azurerm_container_registry_scope_map.oss_scope_map.id
+}
+
+resource "azurerm_container_registry_token_password" "oss_registry_token_password" {
+  container_registry_token_id = azurerm_container_registry_token.oss_registry_token.id
+
+  password1 {
+  }
+}

--- a/cluster/terraform-jx-registry-acr-oss/outputs.tf
+++ b/cluster/terraform-jx-registry-acr-oss/outputs.tf
@@ -1,0 +1,9 @@
+output "oss_token_name" {
+  value = length(azurerm_container_registry.oss_acr) > 0 ? azurerm_container_registry_token.oss_registry_token.name : ""
+  sensitive = true
+}
+
+output "oss_token_password" {
+  value = length(azurerm_container_registry.oss_acr) > 0 ? azurerm_container_registry_token_password.oss_registry_token_password.password1[0].value : ""
+  sensitive = true
+}

--- a/cluster/terraform-jx-registry-acr-oss/outputs.tf
+++ b/cluster/terraform-jx-registry-acr-oss/outputs.tf
@@ -1,9 +1,7 @@
 output "oss_token_name" {
   value = length(azurerm_container_registry.oss_acr) > 0 ? azurerm_container_registry_token.oss_registry_token.name : ""
-  sensitive = true
 }
 
 output "oss_token_password" {
   value = length(azurerm_container_registry.oss_acr) > 0 ? azurerm_container_registry_token_password.oss_registry_token_password.password1[0].value : ""
-  sensitive = true
 }

--- a/cluster/terraform-jx-registry-acr-oss/variables.tf
+++ b/cluster/terraform-jx-registry-acr-oss/variables.tf
@@ -17,6 +17,16 @@ variable "principal_id" {
   description = "Principal id of the identity to give authorisation to push/pull to container registry"
   type        = string
 }
+variable "oss_registry_scope_map_name" {
+  description = "Name of OSS registry scope map"
+  type        = string
+  default     = ""
+}
+variable "oss_registry_token_name" {
+  description = "Name of OSS registry token"
+  type        = string
+  default     = ""
+}
 variable "sku" {
   description = "SKU of the container registry"
   type        = string


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Create auth token for OSS ACR and pass the credentials as environment variables to JX boot - `JX_REPOSITORY_USERNAME` and `JX_REPOSITORY_PASSWORD`

When set, these env vars allow JX to use ACR as a helm chart registry

## Changes Made
- [X] New resources added
- [ ] Existing resources modified
- [ ] Resources deleted
- [X] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.