### PR TITLE
feat: add ACR cache rules for quay.io and mcr.microsoft.com

### DIFF
--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -56,3 +56,19 @@ resource "azurerm_container_registry_cache_rule" "cache_rule" {
   source_repo           = "docker.io/*"
   credential_set_id     = "${azurerm_container_registry.acr[0].id}/credentialSets/dockerhub-cred"
 }
+
+resource "azurerm_container_registry_cache_rule" "cache_rule_mcr" {
+  count                 = var.acr_enabled && var.external_registry_url == "" && var.use_existing_acr_name == null ? 1 : 0
+  name                  = "mcr-microsoft-com"
+  container_registry_id = azurerm_container_registry.acr[0].id
+  target_repo           = "mcr-microsoft-com/*"
+  source_repo           = "mcr.microsoft.com/*"
+}
+
+resource "azurerm_container_registry_cache_rule" "cache_rule_quay" {
+  count                 = var.acr_enabled && var.external_registry_url == "" && var.use_existing_acr_name == null ? 1 : 0
+  name                  = "quay-io"
+  container_registry_id = azurerm_container_registry.acr[0].id
+  target_repo           = "quay-io/*"
+  source_repo           = "quay.io/*"
+}


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description

Add cache rules for quay.io and mcr.microsoft.com

Neither have stingy rate limits for anonymous pulls (like dockerhub) but we pay for enhanced ACR bandwidth and this provides an extra layer of safety in case the upstream repos are down for any reason. Both support unauthenticated pulls so no credentials are required

List of supported registries: https://learn.microsoft.com/en-us/azure/container-registry/artifact-cache-overview#upstream-support

## Changes Made
- [X] New resources added
- [ ] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.