### PR TITLE
feat: enable ACR OCI auth within bootjob env vars

### DIFF
--- a/cluster/local.tf
+++ b/cluster/local.tf
@@ -14,9 +14,16 @@ locals {
 
   merged_secrets = merge(local.registry_secrets)
 
-  job_secret_env_vars = var.key_vault_enabled ? {
+  job_secret_env_vars_vault = var.key_vault_enabled ? {
     AZURE_TENANT_ID       = module.secrets.tenant_id
     AZURE_SUBSCRIPTION_ID = module.secrets.subscription_id
     AZURE_CLIENT_ID       = module.secrets.client_id
   } : {}
+
+  job_secret_env_vars_acr_chart_repository = var.acr_chart_registry_enabled ? {
+    JX_REPOSITORY_USERNAME        = module.registry.admin_username,
+    JX_REPOSITORY_PASSWORD        = module.registry.admin_password,
+  } : {}
+
+  job_secret_env_vars = merge(local.job_secret_env_vars_vault, local.job_secret_env_vars_acr_chart_repository)
 }

--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -134,14 +134,15 @@ module "oss_registry" {
 }
 
 module "jx-boot" {
-  source               = "./terraform-jx-boot"
-  depends_on           = [module.cluster]
-  jx_git_url           = var.jx_git_url
-  jx_bot_username      = var.jx_bot_username
-  jx_bot_token         = var.jx_bot_token
-  job_secret_env_vars  = local.job_secret_env_vars
-  install_vault        = !var.key_vault_enabled
-  install_kuberhealthy = var.install_kuberhealthy
+  source                     = "./terraform-jx-boot"
+  depends_on                 = [module.cluster]
+  jx_git_url                 = var.jx_git_url
+  jx_bot_username            = var.jx_bot_username
+  jx_bot_token               = var.jx_bot_token
+  job_secret_env_vars        = local.job_secret_env_vars
+  install_vault              = !var.key_vault_enabled
+  install_kuberhealthy       = var.install_kuberhealthy
+  acr_chart_registry_enabled = var.acr_chart_registry_enabled
 }
 
 module "dns" {

--- a/cluster/terraform-jx-boot/variables.tf
+++ b/cluster/terraform-jx-boot/variables.tf
@@ -35,3 +35,9 @@ variable "install_kuberhealthy" {
   type        = bool
   default     = true
 }
+
+variable "acr_chart_registry_enabled" {
+  description = "Flag to indicate if the ACR should be used as the chart repository for Jenkins X"
+  type        = bool
+  default     = false
+}

--- a/cluster/terraform-jx-boot/variables.tf
+++ b/cluster/terraform-jx-boot/variables.tf
@@ -35,9 +35,3 @@ variable "install_kuberhealthy" {
   type        = bool
   default     = true
 }
-
-variable "acr_chart_registry_enabled" {
-  description = "Flag to indicate if the ACR should be used as the chart repository for Jenkins X"
-  type        = bool
-  default     = false
-}

--- a/cluster/terraform-jx-boot/variables.tf
+++ b/cluster/terraform-jx-boot/variables.tf
@@ -35,3 +35,9 @@ variable "install_kuberhealthy" {
   type        = bool
   default     = true
 }
+
+variable "acr_chart_registry_enabled" {
+  description = "Flag to specify if ACR should be used as chart repository"
+  type        = bool
+  default     = false
+}

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -465,3 +465,9 @@ variable "enable_defender_analytics" {
 variable "enable_auto_upgrades" {
   type = bool
 }
+
+variable "acr_chart_registry_enabled" {
+  type        = bool
+  description = "BETA: Flag to enable ACR as an OCI chart registry"
+  default     = false
+}

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,7 @@ module "cluster" {
   external_registry_url                 = var.external_registry_url
   use_existing_acr_name                 = var.use_existing_acr_name
   use_existing_acr_resource_group_name  = var.use_existing_acr_resource_group_name
+  acr_chart_registry_enabled            = var.acr_chart_registry_enabled
   oss_registry_name                     = var.oss_registry_name
   jx_bot_token                          = var.jx_bot_token
   jx_git_url                            = var.jx_git_url

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -18,6 +18,7 @@ orchestrator_version             = "1.31.6"
 azure_policy_bool                = false
 cost_analysis_bool               = true
 acr_enabled                      = true
+acr_chart_registry_enabled       = true
 install_kuberhealthy             = true
 dns_resources_enabled            = true
 default_suk_bool                 = true

--- a/variables.tf
+++ b/variables.tf
@@ -407,6 +407,12 @@ variable "use_existing_acr_name" {
   default     = null
 }
 
+variable "acr_chart_registry_enabled" {
+  type        = bool
+  description = "BETA: Flag to enable ACR as an OCI chart registry"
+  default     = false
+}
+
 variable "use_existing_acr_resource_group_name" {
   description = "Name of the resources group of the existing ACR that you would like to use, e.g. use this in multicluster setup, when you want to use DEV cluster ACR."
   type        = string


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Define `acr_chart_registry_enabled` - and set to true. This addes `JX_REPOSITORY_USERNAME` and `JX_REPOSITORY_PASSWORD` env vars to `jx-boot-job-env-vars`


## Changes Made
- [X] New resources added
- [X] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.