### PR TITLE
fix: set port allocation as a multiple of 8

### DIFF
--- a/cluster/local.tf
+++ b/cluster/local.tf
@@ -16,11 +16,11 @@ locals {
     var.max_mlbuild_node_count
   ) : 0
 
-  # Allocate node ports based on the maximum number of nodes the cluster can scale to, with 64,000 ports allowed per-outbound IP
-  # ports_allocated = (64000 * number of outbound IPs) / (max total nodes) rounded down to nearest 100
+  # Allocate node ports based on the maximum number of nodes the cluster can scale to, with 64,000 ports allowed per-outbound IP.
+  # Result is the largest multiple of 8 that does not exceed (64000 * outbound_ip_count / max_nodes).
   cluster_loadbalancer_outbound_ports_allocated = var.enable_loadbalancer_outbound_ports_allocation ? floor(
-    floor(64000 * var.cluster_managed_outbound_ip_count / local.total_max_nodes) / 100
-  ) * 100 : 0
+    64000 * var.cluster_managed_outbound_ip_count / local.total_max_nodes / 8
+  ) * 8 : 0
 
   registry_secrets = {
     jx-dev-registry-username : module.registry.admin_username,


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
TF plan fails with:

```
"Load balancer profile allocated ports must be a multiple of 8. Refer to https://aka.ms/aks/slb-ports for more details."
```

This change simplifies the port allocation formula, rounding the allocated ports to a multiple of 8:
```
ports_per_node = floor(((64000 * ip_count)/ total_nodes) / 8)) * 8
```
This means the number of ports is always <= the maximum while being divisible by 8

For the current example, then:

```
max_ports_per_node = 64,000 * 2 / 52 = 2461.5
Rounded down to nearest 8 = 2396 (which is 8 times 296)
```

## Changes Made
- [ ] New resources added
- [X] Existing resources modified
- [ ] Resources deleted
- [X] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.