### PR TITLE
chore: undo outbound ports allocation

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -31,7 +31,7 @@ oss_acr_enabled                               = true
 oss_acr_pull_enabled                          = false
 enable_node_zone_spanning                     = false
 cluster_managed_outbound_ip_count             = 2
-enable_loadbalancer_outbound_ports_allocation = true
+enable_loadbalancer_outbound_ports_allocation = false
 cluster_loadbalancer_idle_timeout_in_minutes  = 10
 
 # Machines


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description

Previous apply failed with:

```
Load balancer profile allocated ports 2368 is not in an allowable range given the number of nodes and IPs provisioned. Total node count 85 requires 201280 ports but only 128000 ports are available given 2 outbound public IPs.
```

Let's revert manual port allocation for nodes, while resizing the cluster node count. 

## Changes Made
- [ ] New resources added
- [X] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.