### PR TITLE
feat: create toggle for API Server VNET integration

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -126,6 +126,8 @@ module "cluster" {
   cluster_managed_outbound_ip_count             = var.cluster_managed_outbound_ip_count
   cluster_loadbalancer_idle_timeout_in_minutes  = var.cluster_loadbalancer_idle_timeout_in_minutes
   cluster_loadbalancer_outbound_ports_allocated = local.cluster_loadbalancer_outbound_ports_allocated
+  enable_apiserver_vnet_integration              = var.enable_apiserver_vnet_integration
+  api_server_subnet_cidr                        = var.api_server_subnet_cidr
 }
 
 module "registry" {

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -90,6 +90,14 @@ resource "azurerm_kubernetes_cluster" "aks" {
     type = "SystemAssigned"
   }
 
+  dynamic "api_server_access_profile" {
+    for_each = var.api_server_subnet_id != null ? [1] : []
+    content {
+      virtual_network_integration_enabled = true
+      subnet_id                           = var.api_server_subnet_id
+    }
+  }
+
   lifecycle { ignore_changes = [maintenance_window_node_os[0].utc_offset] }
 }
 

--- a/cluster/terraform-jx-cluster-aks/cluster/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/variables.tf
@@ -350,3 +350,9 @@ variable "cluster_loadbalancer_outbound_ports_allocated" {
   type        = number
   description = "The number of outbound ports to be allocated for each node in the cluster load balancer."
 }
+
+variable "api_server_subnet_id" {
+  type        = string
+  default     = null
+  description = "Subnet ID for API server VNET integration. When null, VNET integration is not configured."
+}

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=4.23.0"
+      version = ">=4.46.0"
     }
   }
 }
@@ -116,10 +116,19 @@ module "cluster" {
   cluster_managed_outbound_ip_count             = var.cluster_managed_outbound_ip_count
   cluster_loadbalancer_idle_timeout_in_minutes  = var.cluster_loadbalancer_idle_timeout_in_minutes
   cluster_loadbalancer_outbound_ports_allocated = var.cluster_loadbalancer_outbound_ports_allocated
+  api_server_subnet_id                          = var.enable_apiserver_vnet_integration ? module.vnet.api_server_subnet_id : null
 }
 
 resource "azurerm_role_assignment" "cluster_outbound_network_contributor" {
   scope                = azurerm_resource_group.cluster.id
+  role_definition_name = "Network Contributor"
+  principal_id         = module.cluster.kubernetes_cluster.identity[0].principal_id
+  depends_on           = [module.cluster]
+}
+
+resource "azurerm_role_assignment" "cluster_api_server_subnet_network_contributor" {
+  count                = var.enable_apiserver_vnet_integration ? 1 : 0
+  scope                = module.vnet.api_server_subnet_id
   role_definition_name = "Network Contributor"
   principal_id         = module.cluster.kubernetes_cluster.identity[0].principal_id
   depends_on           = [module.cluster]
@@ -130,11 +139,13 @@ resource "azurerm_role_assignment" "cluster_outbound_network_contributor" {
 // ----------------------------------------------------------------------------
 
 module "vnet" {
-  source         = "./vnet"
-  resource_group = azurerm_resource_group.network.name
-  vnet_cidr      = var.vnet_cidr
-  subnet_cidr    = var.subnet_cidr
-  network_name   = local.network_name
-  subnet_name    = local.subnet_name
-  location       = var.location
+  source                            = "./vnet"
+  resource_group                    = azurerm_resource_group.network.name
+  vnet_cidr                         = var.vnet_cidr
+  subnet_cidr                       = var.subnet_cidr
+  network_name                      = local.network_name
+  subnet_name                       = local.subnet_name
+  location                          = var.location
+  enable_apiserver_vnet_integration = var.enable_apiserver_vnet_integration
+  api_server_subnet_cidr            = var.api_server_subnet_cidr
 }

--- a/cluster/terraform-jx-cluster-aks/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/variables.tf
@@ -366,3 +366,15 @@ variable "cluster_loadbalancer_outbound_ports_allocated" {
   type        = number
   description = "Number of desired SNAT ports per VM in the cluster load balancer. Must be between 0 and 64000 inclusive."
 }
+
+variable "enable_apiserver_vnet_integration" {
+  type        = bool
+  default     = false
+  description = "Flag to enable API server VNET integration."
+}
+
+variable "api_server_subnet_cidr" {
+  type        = string
+  default     = "10.8.1.0/28"
+  description = "CIDR for the API server VNET integration subnet."
+}

--- a/cluster/terraform-jx-cluster-aks/vnet/main.tf
+++ b/cluster/terraform-jx-cluster-aks/vnet/main.tf
@@ -14,3 +14,21 @@ resource "azurerm_subnet" "cluster_subnet" {
   private_endpoint_network_policies = "Enabled"
   service_endpoints                 = ["Microsoft.Storage"]
 }
+
+resource "azurerm_subnet" "api_server_subnet" {
+  count                = var.enable_apiserver_vnet_integration ? 1 : 0
+  name                 = "${var.subnet_name}-apiserver"
+  resource_group_name  = var.resource_group
+  virtual_network_name = azurerm_virtual_network.cluster.name
+  address_prefixes     = [var.api_server_subnet_cidr]
+
+  delegation {
+    name = "aks-api-server"
+    service_delegation {
+      name = "Microsoft.ContainerService/managedClusters"
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
+}

--- a/cluster/terraform-jx-cluster-aks/vnet/outputs.tf
+++ b/cluster/terraform-jx-cluster-aks/vnet/outputs.tf
@@ -1,3 +1,7 @@
 output "subnet_id" {
   value = azurerm_subnet.cluster_subnet.id
 }
+
+output "api_server_subnet_id" {
+  value = var.enable_apiserver_vnet_integration ? azurerm_subnet.api_server_subnet[0].id : null
+}

--- a/cluster/terraform-jx-cluster-aks/vnet/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/vnet/variables.tf
@@ -16,3 +16,12 @@ variable "subnet_name" {
 variable "location" {
   type = string
 }
+variable "enable_apiserver_vnet_integration" {
+  type        = bool
+  default     = false
+  description = "Flag to enable API server VNET integration."
+}
+variable "api_server_subnet_cidr" {
+  type        = string
+  description = "CIDR for the API server VNET integration subnet. Minimum /28."
+}

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -570,3 +570,15 @@ variable "enable_loadbalancer_outbound_ports_allocation" {
   default     = false
   description = "If true, calculates and sets outbound SNAT ports per node based on the total max node count and outbound IPs."
 }
+
+variable "enable_apiserver_vnet_integration" {
+  type        = bool
+  default     = false
+  description = "Flag to enable API server VNET integration."
+}
+
+variable "api_server_subnet_cidr" {
+  type        = string
+  default     = "10.8.1.0/28"
+  description = "CIDR for the API server VNET integration subnet."
+}

--- a/main.tf
+++ b/main.tf
@@ -108,6 +108,8 @@ module "cluster" {
   cluster_managed_outbound_ip_count            = var.cluster_managed_outbound_ip_count
   cluster_loadbalancer_idle_timeout_in_minutes  = var.cluster_loadbalancer_idle_timeout_in_minutes
   enable_loadbalancer_outbound_ports_allocation = var.enable_loadbalancer_outbound_ports_allocation
+  enable_apiserver_vnet_integration              = var.enable_apiserver_vnet_integration
+  api_server_subnet_cidr                        = var.api_server_subnet_cidr
 }
 
 output "connect" {

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -33,6 +33,8 @@ enable_node_zone_spanning                     = false
 cluster_managed_outbound_ip_count             = 2
 enable_loadbalancer_outbound_ports_allocation = false
 cluster_loadbalancer_idle_timeout_in_minutes  = 10
+enable_apiserver_vnet_integration             = false
+api_server_subnet_cidr                        = "10.8.1.0/28"
 
 # Machines
 min_node_count = 5

--- a/variables.tf
+++ b/variables.tf
@@ -571,3 +571,15 @@ variable "enable_loadbalancer_outbound_ports_allocation" {
   description = "If true, calculates and sets outbound SNAT ports per node based on the total max node count and outbound IPs."
 }
 
+variable "enable_apiserver_vnet_integration" {
+  type        = bool
+  default     = false
+  description = "Flag to enable API server VNET integration. When true, creates a dedicated API server subnet and enables the api_server_access_profile on the AKS cluster. This is irreversible once applied."
+}
+
+variable "api_server_subnet_cidr" {
+  type        = string
+  default     = "10.8.1.0/28"
+  description = "CIDR for the dedicated API server VNET integration subnet. Minimum /28."
+}
+


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description

Creates `enable_apiserver_vnet_integration` toggle, which:
* Creates a dedicated cluster subnet
* sets `api_server_access_profile.content.virtual_network_integration_enabled = true`
When the toggle is set to `true`.

The AKS API server is currently _public_, meaning the cluster nodes communicate with it via the outbound load balancer.

Setting an API server access profile with the [API Server VNET Integration enabled](https://learn.microsoft.com/en-us/azure/aks/api-server-vnet-integration) puts the API server behind a private subnet, meaning node-to-API traffic is completely internal

This is a relatively small cost for the current Load Balancer but the costs could spiral  if we switched to NAT Gateway or similar.

Test PR: https://github.com/spring-financial-group/terraform-playground/pull/51
TF output: https://app.terraform.io/app/Mqube/workspaces/terraform-playground/runs/run-ehqBM6o4CrrKYiY7

Note: once applied, this change is irreversible unless the cluster is recreated. A boolean toggle is not ideal and we should be cautious about using it until it's tested on playground!!!!

## Changes Made
- [ ] New resources added
- [ ] Existing resources modified
- [ ] Resources deleted
- [X] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.