### PR TITLE
chore: bump min azurerm version to 4.46.0

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -8,7 +8,7 @@ terraform {
       version = ">=1.13.3"
     }
     azurerm = {
-      version = ">=4.23.0"
+      version = ">=4.46.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/cluster/terraform-jx-azure-storage/main.tf
+++ b/cluster/terraform-jx-azure-storage/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 0.13.2"
   required_providers {
     azurerm = {
-      version = ">=4.23.0"
+      version = ">=4.46.0"
     }
   }
 }

--- a/cluster/terraform-jx-azuredns/main.tf
+++ b/cluster/terraform-jx-azuredns/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=4.23.0"
+      version = ">=4.46.0"
     }
   }
 }

--- a/cluster/terraform-jx-azurekeyvault/main.tf
+++ b/cluster/terraform-jx-azurekeyvault/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=4.23.0"
+      version = ">=4.46.0"
     }
   }
 }

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.4.6"
   required_providers {
     azurerm = {
-      version = ">=4.23.0"
+      version = ">=4.46.0"
     }
   }
 }

--- a/cluster/terraform-jx-registry-acr-oss/main.tf
+++ b/cluster/terraform-jx-registry-acr-oss/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.3.2"
   required_providers {
     azurerm = {
-      version = ">=4.23.0"
+      version = ">=4.46.0"
     }
   }
 }

--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -6,7 +6,7 @@ terraform {
   required_version = ">= 1.3.2"
   required_providers {
     azurerm = {
-      version = ">=4.23.0"
+      version = ">=4.46.0"
     }
     azuread = {
       source  = "hashicorp/azuread"


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description

Bump minimum `azurerm` version to `4.46.0`

Required for `virtual_network_integration_enabled` flag. See release: https://github.com/hashicorp/terraform-provider-azurerm/releases/tag/v4.46.0

## Changes Made
- [ ] New resources added
- [ ] Existing resources modified
- [ ] Resources deleted
- [X] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.