### PR TITLE
chore: enable additional port allocation to nodes

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -32,7 +32,7 @@ oss_acr_enabled                               = true
 oss_acr_pull_enabled                          = false
 enable_node_zone_spanning                     = false
 cluster_managed_outbound_ip_count             = 2
-enable_loadbalancer_outbound_ports_allocation = false
+enable_loadbalancer_outbound_ports_allocation = true
 cluster_loadbalancer_idle_timeout_in_minutes  = 10
 enable_cluster_admin_rbac                     = true
 


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description

set `enable_loadbalancer_outbound_ports_allocation: true` to grant additional ports per-node based on the calculated formula (see `cluster/local.tf`)

Creates a new load balancer in order to do this, so should be done out-of-hours

This allocates ~1800 ports, which is not a lot but better than the ~1000 allocated currently. This can be increased if we add more IP addresses to the load balancer

## Changes Made
- [ ] New resources added
- [X] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [X] Terraform plan has been reviewed and validated.
- [X] Any potential impact on existing infrastructure has been assessed.
- [X] Documentation has been updated, if necessary, to reflect the changes made.