### PR TITLE
chore: add Gateway API read permissions to dev ClusterRole

### DIFF
--- a/cluster/terraform-jx-cluster-aks/rbac/dev/jx-dev-cr.yaml
+++ b/cluster/terraform-jx-cluster-aks/rbac/dev/jx-dev-cr.yaml
@@ -68,3 +68,32 @@ rules:
 - apiGroups: ["lighthouse.jenkins.io"]
   resources: ["lighthousejobs", "lighthousejobs/status", "lighthousebreakpoints", "lighthousebreakpoints/status"]
   verbs: ["get", "list", "create", "delete", "update"]
+- apiGroups: ["gateway.networking.k8s.io"]
+  resources:
+  - backendtlspolicies
+  - gatewayclasses
+  - gateways
+  - grpcroutes
+  - httproutes
+  - listenersets
+  - referencegrants
+  - tcproutes
+  - tlsroutes
+  - udproutes
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["gateway.networking.x-k8s.io"]
+  resources:
+  - xbackendtrafficpolicies
+  - xmeshes
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["gateway.envoyproxy.io"]
+  resources:
+  - backends
+  - backendtrafficpolicies
+  - clienttrafficpolicies
+  - envoyextensionpolicies
+  - envoypatchpolicies
+  - envoyproxies
+  - httproutefilters
+  - securitypolicies
+  verbs: ["get", "list", "watch"]


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Add read permissions for Gateway API and Envoy Gateway resources to the jx-dev `ClusterRole`

Allows devs to see the resources that are handling traffic :)

## Test

https://github.com/spring-financial-group/terraform-playground/pull/74

https://app.terraform.io/app/Mqube/workspaces/terraform-playground/runs/run-8rbsqUZ1t2Svz4ns

Changes the deployed role to add the new permissions

## Changes Made
- [ ] New resources added
- [X] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.