### PR TITLE
feat: upgrade to newer ml node type

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -45,7 +45,7 @@ node_size      = "Standard_D8s_v5"
 
 # Ml nodes
 use_spot_ml       = true
-ml_node_size      = "Standard_NV24s_v3"
+ml_node_size      = "Standard_NC4as_T4_v3"
 min_ml_node_count = 2
 max_ml_node_count = 6
 


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Updating to a much smaller much cheaper node. Confirmed resource quota for all clients 👍 

Will deploy to build this evening.

I'm going with NC4as_T4_v3 as it's the smallest node we can get with a gpu (4 CPU & 28GB ram). We're absolutely not CPU or RAM constrained so this is the correct approach.

There's a couple of things going on there though, this chart explains the dials I'm also going to fiddle with once we deploy this node type. 

The main thing is that we can split the gpus down (v important as we'll have access to 16Gb GPU vs 8Gb gpu). I think we definitely want to up the replicas 2 -> 4, giving us the same amount of vRAM per pod. There is an argument to be had for going further but will need to discuss with Rafay.

```markdown
┌─────────────────────────────────┬────────────────────────┬─────────────────┬─────────────────┬──────────────────┬─────────────────┬──────────────────────────────────────┐
│                                 │ NV24s_v3 (current) r=2 │ NC4as_T4_v3 r=2 │ NC4as_T4_v3 r=3 │ NC4as_T4_v3 r=4  │ NC4as_T4_v3 r=5 │           NC4as_T4_v3 r=6            │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Physical GPUs / node            │ 2 × M60                │ 1 × T4          │ 1 × T4          │ 1 × T4           │ 1 × T4          │ 1 × T4                               │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ VRAM / physical GPU             │ 8 GB                   │ 16 GB           │ 16 GB           │ 16 GB            │ 16 GB           │ 16 GB                                │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ VRAM / slot (shared)            │ 8 GB (÷2 pods)         │ 16 GB (÷2 pods) │ 16 GB (÷3 pods) │ 16 GB (÷4 pods)  │ 16 GB (÷5 pods) │ 16 GB (÷6 pods)                      │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ vCPU / RAM per node             │ 24 / 224 GiB           │ 4 / 28 GiB      │ 4 / 28 GiB      │ 4 / 28 GiB       │ 4 / 28 GiB      │ 4 / 28 GiB                           │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ K8s GPU slots / node            │ 4                      │ 2               │ 3               │ 4                │ 5               │ 6                                    │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Spot $/hr per node (UK South)   │ $0.5267                │ $0.2255         │ $0.2255         │ $0.2255          │ $0.2255         │ $0.2255                              │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Spot $/slot/hr                  │ $0.1317                │ $0.1128         │ $0.0752         │ $0.0564          │ $0.0451         │ $0.0376                              │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Spot $/month per node (730h)    │ $384.49                │ $164.62         │ $164.62         │ $164.62          │ $164.62         │ $164.62                              │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Nodes needed for 24 slots       │ 6                      │ 12              │ 8               │ 6                │ 5               │ 4                                    │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Monthly cost @ 24 slots (spot)  │ $2,307                 │ $1,975          │ $1,317          │ $988             │ $823            │ $658                                 │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Δ vs current                    │ —                      │ −14%            │ −43%            │ −57%             │ −64%            │ −71%                                 │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Worst-case VRAM used (3 GB/pod) │ 6 GB / 8 GB            │ 6 GB / 16 GB    │ 9 GB / 16 GB    │ 12 GB / 16 GB    │ 15 GB / 16 GB   │ 18 GB / 16 GB                        │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Headroom per pod (2.5 GB model) │ 5.5 GB free            │ 13.5 GB free    │ 10.5 GB free    │ 6 GB free        │ 3.2 GB free     │ 2.7 GB free                          │
├─────────────────────────────────┼────────────────────────┼─────────────────┼─────────────────┼──────────────────┼─────────────────┼──────────────────────────────────────┤
│ Time slicing risk               │ Low                    │ Very low        │ Very low        │ Low (sweet spot) │ Aggressive      │ Unsafe — 2.5 GB service exceeds slot │
└─────────────────────────────────┴────────────────────────┴─────────────────┴─────────────────┴──────────────────┴─────────────────┴──────────────────────────────────────┘
```

Relevant timeslicing PR:
https://github.com/spring-financial-group/JX3_Azure_Vault_Dev_Cluster/pull/73412

## Changes Made
- [ ] New resources added
- [x] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [x] Terraform plan has been reviewed and validated.
- [x] Any potential impact on existing infrastructure has been assessed.
- [x] Documentation has been updated, if necessary, to reflect the changes made.