### PR TITLE
fix: set gpu_driver as Install

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -46,6 +46,7 @@ node_size      = "Standard_D8s_v5"
 # Ml nodes
 use_spot_ml       = true
 ml_node_size      = "Standard_NC4as_T4_v3"
+gpu_driver_ml     = "Install"
 min_ml_node_count = 2
 max_ml_node_count = 6
 

--- a/variables.tf
+++ b/variables.tf
@@ -135,7 +135,7 @@ variable "llm_node_zones" {
 
 variable "gpu_driver_llm" {
   type        = string
-  default = "Install"
+  default     = "Install"
   description = "The GPU driver to use for the LLM nodepool. Options are 'nvidia' or 'amd'."
 }
 
@@ -181,7 +181,7 @@ variable "ml_node_zones" {
 }
 variable "gpu_driver_ml" {
   type        = string
-  default = null
+  default     = "Install"
   description = "The GPU driver to use for the LLM nodepool. Options are 'nvidia' or 'amd'."
 }
 
@@ -481,9 +481,9 @@ variable "use_existing_acr_resource_group_name" {
 }
 
 variable "enable_dev_acr_pull" {
-    description = "Flag to grant MQube Product Engineering Team ACR pull permissions"
-    type        = bool
-    default     = false
+  description = "Flag to grant MQube Product Engineering Team ACR pull permissions"
+  type        = bool
+  default     = false
 }
 
 variable "enable_mqube_tech_acr_readonly" {


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
gpudriver was being set as null for the ml nodes. Setting as Install to replicate state.

## Changes Made
- [ ] New resources added
- [x] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.