### PR TITLE
feat: set ml_eviction_policy as Delete (default is Deallocate)

### DIFF
--- a/cluster/main.tf
+++ b/cluster/main.tf
@@ -77,6 +77,7 @@ module "cluster" {
   max_node_surge                        = var.max_node_surge
   use_spot_ml                           = var.use_spot_ml
   spot_max_price_ml                     = var.spot_max_price_ml
+  ml_eviction_policy                    = var.ml_eviction_policy
   ml_node_count                         = var.ml_node_count
   min_ml_node_count                     = var.min_ml_node_count
   max_ml_node_count                     = var.max_ml_node_count

--- a/cluster/terraform-jx-cluster-aks/cluster/main.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/main.tf
@@ -98,7 +98,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "mlnode" {
   count                       = var.ml_node_size == "" ? 0 : 1
   name                        = "mlnode"
   priority                    = var.use_spot_ml ? "Spot" : "Regular"
-  eviction_policy             = var.use_spot_ml ? "Deallocate" : null
+  eviction_policy             = var.use_spot_ml ? var.ml_eviction_policy : null
   spot_max_price              = var.use_spot_ml ? var.spot_max_price_ml : null
   kubernetes_cluster_id       = azurerm_kubernetes_cluster.aks.id
   vm_size                     = var.ml_node_size

--- a/cluster/terraform-jx-cluster-aks/cluster/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/variables.tf
@@ -100,7 +100,6 @@ variable "spot_max_price_ml" {
 
 variable "ml_eviction_policy" {
   type        = string
-  default     = "Deallocate"
   description = "Eviction policy for the ML spot node pool. 'Delete' is recommended by Azure for AKS spot pools; 'Deallocate' preserves the pre-existing behaviour."
 }
 

--- a/cluster/terraform-jx-cluster-aks/cluster/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/cluster/variables.tf
@@ -98,6 +98,12 @@ variable "spot_max_price_ml" {
   description = "The maximum price you're willing to pay in USD per virtual machine, -1 to go to the maximum price"
 }
 
+variable "ml_eviction_policy" {
+  type        = string
+  default     = "Deallocate"
+  description = "Eviction policy for the ML spot node pool. 'Delete' is recommended by Azure for AKS spot pools; 'Deallocate' preserves the pre-existing behaviour."
+}
+
 variable "ml_node_size" {
   type        = string
   default     = ""

--- a/cluster/terraform-jx-cluster-aks/main.tf
+++ b/cluster/terraform-jx-cluster-aks/main.tf
@@ -69,6 +69,7 @@ module "cluster" {
   max_node_surge                        = var.max_node_surge
   use_spot_ml                           = var.use_spot_ml
   spot_max_price_ml                     = var.spot_max_price_ml
+  ml_eviction_policy                    = var.ml_eviction_policy
   ml_node_count                         = var.ml_node_count
   min_ml_node_count                     = var.min_ml_node_count
   max_ml_node_count                     = var.max_ml_node_count

--- a/cluster/terraform-jx-cluster-aks/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/variables.tf
@@ -97,7 +97,6 @@ variable "spot_max_price_ml" {
 
 variable "ml_eviction_policy" {
   type        = string
-  default     = "Deallocate"
   description = "Eviction policy for the ML spot node pool. 'Delete' is recommended by Azure for AKS spot pools; 'Deallocate' preserves the pre-existing behaviour."
 }
 

--- a/cluster/terraform-jx-cluster-aks/variables.tf
+++ b/cluster/terraform-jx-cluster-aks/variables.tf
@@ -94,6 +94,13 @@ variable "spot_max_price_ml" {
   default     = -1
   description = "The maximum price you're willing to pay in USD per virtual machine, -1 to go to the maximum price"
 }
+
+variable "ml_eviction_policy" {
+  type        = string
+  default     = "Deallocate"
+  description = "Eviction policy for the ML spot node pool. 'Delete' is recommended by Azure for AKS spot pools; 'Deallocate' preserves the pre-existing behaviour."
+}
+
 variable "ml_node_size" {
   type        = string
   default     = ""

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -146,7 +146,6 @@ variable "spot_max_price_ml" {
 
 variable "ml_eviction_policy" {
   type        = string
-  default     = "Deallocate"
   description = "Eviction policy for the ML spot node pool. 'Delete' is recommended by Azure for AKS spot pools; 'Deallocate' preserves the pre-existing behaviour."
 }
 

--- a/cluster/variables.tf
+++ b/cluster/variables.tf
@@ -144,6 +144,12 @@ variable "spot_max_price_ml" {
   description = "The maximum price you're willing to pay in USD per virtual machine, -1 to go to the maximum price"
 }
 
+variable "ml_eviction_policy" {
+  type        = string
+  default     = "Deallocate"
+  description = "Eviction policy for the ML spot node pool. 'Delete' is recommended by Azure for AKS spot pools; 'Deallocate' preserves the pre-existing behaviour."
+}
+
 variable "ml_node_size" {
   type        = string
   default     = ""

--- a/main.tf
+++ b/main.tf
@@ -50,6 +50,7 @@ module "cluster" {
   node_zones                                    = var.node_zones
   use_spot_ml                                   = var.use_spot_ml
   spot_max_price_ml                             = var.spot_max_price_ml
+  ml_eviction_policy                            = var.ml_eviction_policy
   ml_node_count                                 = var.ml_node_count
   min_ml_node_count                             = var.min_ml_node_count
   max_ml_node_count                             = var.max_ml_node_count

--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -44,11 +44,12 @@ node_size      = "Standard_D8s_v5"
 
 
 # Ml nodes
-use_spot_ml       = true
-ml_node_size      = "Standard_NC4as_T4_v3"
-gpu_driver_ml     = "Install"
-min_ml_node_count = 2
-max_ml_node_count = 6
+use_spot_ml        = true
+ml_node_size       = "Standard_NC4as_T4_v3"
+gpu_driver_ml      = "Install"
+min_ml_node_count  = 2
+max_ml_node_count  = 6
+ml_eviction_policy = "Delete"
 
 # LLM nodes
 use_spot_llm       = true

--- a/variables.tf
+++ b/variables.tf
@@ -154,6 +154,12 @@ variable "spot_max_price_ml" {
   description = "The maximum price you're willing to pay in USD per virtual machine, -1 to go to the maximum price"
 }
 
+variable "ml_eviction_policy" {
+  type        = string
+  default     = "Deallocate"
+  description = "Eviction policy for the ML spot node pool. 'Delete' is recommended by Azure for AKS spot pools; 'Deallocate' preserves the pre-existing behaviour."
+}
+
 variable "ml_node_size" {
   type        = string
   default     = ""


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Sets ml node eviction policy as Delete (as defaulted my Azure). Made this a config var so that this doesn't break SaaS implementations.

## Changes Made
- [ ] New resources added
- [x] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [x] Terraform plan has been reviewed and validated.
- [x] Any potential impact on existing infrastructure has been assessed.
- [x] Documentation has been updated, if necessary, to reflect the changes made.