### PR TITLE
feat: increase max_ml_node_count 6 -> 12

### DIFF
--- a/values.auto.tfvars
+++ b/values.auto.tfvars
@@ -48,7 +48,7 @@ use_spot_ml        = true
 ml_node_size       = "Standard_NC4as_T4_v3"
 gpu_driver_ml      = "Install"
 min_ml_node_count  = 2
-max_ml_node_count  = 6
+max_ml_node_count  = 12
 ml_eviction_policy = "Delete"
 ml_node_zones      = ["1", "2", "3"]
 


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Increase max number of ml nodes to help with churn.

As the spot nodes are being evicted I'm seeing the node autoscaler fail as its hitting the limit of 6 nodes.

## Changes Made
- [ ] New resources added
- [x] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.