### PR TITLE
chore: update this field as tf mpowered showing enabled

### DIFF
--- a/cluster/terraform-jx-cluster-aks/vnet/main.tf
+++ b/cluster/terraform-jx-cluster-aks/vnet/main.tf
@@ -11,7 +11,7 @@ resource "azurerm_subnet" "cluster_subnet" {
   resource_group_name               = var.resource_group
   virtual_network_name              = azurerm_virtual_network.cluster.name
   address_prefixes                  = [var.subnet_cidr]
-  private_endpoint_network_policies = "Disabled"
+  private_endpoint_network_policies = "Enabled"
 
   service_endpoint {
     service = "Microsoft.Storage"


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description

- Some confusion here, because this is disabled in terraform-jx-azure but enabled in other clients. What has happened is azure has defaulted this, so bringing in the changes to state.
- I can see this is actually active on the portal:

<img width="841" height="428" alt="Screenshot 2026-07-30 at 10 31 07" src="https://github.com/user-attachments/assets/c991496e-2711-45c6-a379-1ce34747211e" />


## Changes Made
- [ ] New resources added
- [x] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.