### PR TITLE
chore: add dhi.io cache rule

### DIFF
--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -66,6 +66,14 @@ resource "azurerm_container_registry_cache_rule" "cache_rule" {
   credential_set_id     = "${azurerm_container_registry.acr[0].id}/credentialSets/dockerhub-cred"
 }
 
+resource "azurerm_container_registry_cache_rule" "cache_rule_dhi" {
+  count                 = var.acr_enabled && var.external_registry_url == "" && var.use_existing_acr_name == null ? 1 : 0
+  name                  = "dhi-io"
+  container_registry_id = azurerm_container_registry.acr[0].id
+  target_repo           = "dhi-io/*"
+  source_repo           = "dhi.io/*"
+}
+
 resource "azurerm_container_registry_cache_rule" "cache_rule_mcr" {
   count                 = var.acr_enabled && var.external_registry_url == "" && var.use_existing_acr_name == null ? 1 : 0
   name                  = "mcr-microsoft-com"

--- a/cluster/terraform-jx-registry-acr/main.tf
+++ b/cluster/terraform-jx-registry-acr/main.tf
@@ -72,6 +72,7 @@ resource "azurerm_container_registry_cache_rule" "cache_rule_dhi" {
   container_registry_id = azurerm_container_registry.acr[0].id
   target_repo           = "dhi-io/*"
   source_repo           = "dhi.io/*"
+  credential_set_id     = "${azurerm_container_registry.acr[0].id}/credentialSets/dockerhub-cred"
 }
 
 resource "azurerm_container_registry_cache_rule" "cache_rule_mcr" {


### PR DESCRIPTION
# Terraform Pull Request: Infrastructure Changes

## Description
Add pullthrough cache for docker hardened images - https://hub.docker.com/hardened-images/catalog

Use same dockerhub creds as the other cache rule

## Changes Made
- [X] New resources added
- [ ] Existing resources modified
- [ ] Resources deleted
- [ ] Infrastructure configuration changes

## Checklist
Please ensure the following before merging:
- [ ] Terraform plan has been reviewed and validated.
- [ ] Any potential impact on existing infrastructure has been assessed.
- [ ] Documentation has been updated, if necessary, to reflect the changes made.